### PR TITLE
Remove Python 2 Support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/parse_this/core.py
+++ b/parse_this/core.py
@@ -1,14 +1,9 @@
-from __future__ import print_function
 import argparse
 import logging
 import re
 import sys
 
-
-try:
-    from itertools import izip_longest as zip_longest
-except ImportError:
-    from itertools import zip_longest
+from itertools import zip_longest
 
 _LOG = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.9",
     ],
 )

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,6 +1,5 @@
-from contextlib import contextmanager
 import sys
-
+from contextlib import contextmanager
 from io import StringIO
 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,10 +1,7 @@
 from contextlib import contextmanager
 import sys
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 
 @contextmanager


### PR DESCRIPTION
Python2 is end of life as of 2020. No need to maintain it. Long live Python3.

Python2 specific code, only imports really, is removed.
Py27 is removed from Github Actions.

Tests:
- pytest OK