### PR TITLE
Add GAction Step to Add Code Coverage as a PR Comment

### DIFF
--- a/.github/workflows/pr-pre-submit-queue.yml
+++ b/.github/workflows/pr-pre-submit-queue.yml
@@ -34,4 +34,4 @@ jobs:
         flake8 parse_this test --count --show-source --statistics
     - name: test with pytest
       run: |
-        pytest
+        pytest --cache-clear --cov=parse_this --no-cov-on-fail test/ > pytest-coverage.txt

--- a/.github/workflows/pr-pre-submit-queue.yml
+++ b/.github/workflows/pr-pre-submit-queue.yml
@@ -2,7 +2,8 @@ name: parse_this pre-submit queues
 
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - "*"
 
 jobs:
   build:

--- a/.github/workflows/pr-pre-submit-queue.yml
+++ b/.github/workflows/pr-pre-submit-queue.yml
@@ -35,3 +35,7 @@ jobs:
     - name: test with pytest
       run: |
         pytest --cache-clear --cov=parse_this --no-cov-on-fail test/ > pytest-coverage.txt
+    - name: add coverage as PR comment
+      uses: coroo/pytest-coverage-commentator@v1.0.2
+      with:
+        pytest-coverage: pytest-coverage.txt

--- a/.github/workflows/publish-package-to-pypi.yml
+++ b/.github/workflows/publish-package-to-pypi.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - setup.py
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ test_results.xml
 # Virtualenv directory
 env*/
 parse_this.iml
+pytest-coverage.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black
-pytest
-pre-commit
 flake8
+pre-commit
+pytest
+pytest-cov


### PR DESCRIPTION
For all PR `pytest` will be run with coverage and the output will be posted as a PR comment.

And the beauty is that this PR should have that comment as well ... it's all very meta if you ask me.