### PR TITLE
Solely Rely on Type Annotations to Infer Type of CLI Args

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,21 @@ parse_this
 
 Makes it easy to parse command line arguments for any function, method or classmethod.
 
-You just finished writing an awesome piece of code and now comes the boring part:
-adding the command line parsing to actually use it ...
+You just finished writing an awesome piece of code and now comes the boring part: adding the command line parsing to
+actually use it ...
 
-So now you need to use the awesome, but very verbose, `argparse` module.
-For each argument of your entry point method you need to add a name, a help
-message and/or a default value. But wait... Your parameters are correctly named
-right!? And you have an awesome docstring for that method. There is probably a
-way of creating the `ArgumentParser` easily right?
+So now you need to use the awesome, but very verbose, `argparse` module. For each argument of your entry point method
+you need to add a name, a help message and/or a default value. But wait... Your parameters are correctly named, right!?
+They also have type hinting, right!? And you have an awesome docstring for that method. There is probably a way of
+creating the `ArgumentParser` easily right?
 
 Yes and it's called `parse_this`!
 
 Usage
 -----
 
-`parse_this` contains a simple way to create a command line interface from an
-entire class. For that you will need to use the `parse_class` class decorator.
+`parse_this` contains a simple way to create a command line interface from an entire class. For that you will need to
+use the `parse_class` class decorator.
 
 ```python
 # script.py
@@ -71,53 +70,44 @@ python script.py 2 --ham 2 do-stuff 2 --spam 2
 
 How does it work **TL;DR version**?
 
-* You need to decorate the methods you want to be usable from the command line
-  using `create_parser`.
-* The `__init__` method arguments and keyword arguments will be the arguments
-  and options of the script command line *i.e.* the first arguments and options
-* The other methods will be transformed into sub-command, again mapping the
-  command line arguments and options to the method's own arguments
+* You need to decorate the methods you want to be usable from the command line  using `create_parser`.
+* The `__init__` method arguments and keyword arguments will be the arguments and options of the script command line *i.e.* the first arguments and options
+* The other methods will be transformed into sub-command, again mapping the command line arguments and options to the method's own arguments
 * All you have to do for this to work is:
   * Decorate your class with `parse_class`
-  * Decorate methods with `create_parser` making it aware of the type of the
-    arguments. Using `Self` to designate the `self` parameter
-  * Document your class and method with properly formed docstring to get help
-    and usage message
+  * Decorate methods with `create_parser`
+  * Document your class and method with properly formed docstring to get help and usage message
+  * Annotate all parameters with their type
   * Call `<YourClass>.parser.call()` and you are done!
 
 
 If you feel like you may need more customization and details, please read on!
 
-* If the `__init__` method is decorated it will be considered the first, or
-  top-level, parser this means that all arguments in your `__init__` will be
-  arguments pass right after invoking you script i.e.
-  `python script.py init_arg_1 init_arg_2 etc...`
-* The description of the top-level parser is taken from the class's docstring or
-  overwritten by the keyword argument `description` of `parse_class`.
-* Each method decorated by `create_parser` will become a subparser of its own.
-  The command name of the subparser is the same as the method name with `_`
-  replaced by `-`. 'Private' methods, whose name start with an `_`, do not have
-  a subparser by default, as this would expose them to the outside. However if you
-  want to expose them you can set the keyword argument `parse_private=True` in
-  `parse_class`. If exposed their command name will not contain the leading `-`
-  as this would be confusing for command parsing. Special methods, such as `__str__`,
-  can be decorated as well. Their command name will be stripped of all `_`s resulting
-  in command names such as `str`.
-* When used in a `parse_class` decorated class `create_parser` can take an extra
-  parameters `name` that will be used as the sub-command name. The same
-  modifications are made to the `name` replacing `_` with `-`
-* When calling `python script.py --help` the help message for **every** parser
-  will be displayed making easier to find what you are looking for
+* If the `__init__` method is decorated it will be considered the first, or top-level, parser this means that all
+  arguments in your `__init__` will be arguments pass right after invoking you script
+  i.e. `python script.py init_arg_1 init_arg_2 etc...`
+* The description of the top-level parser is taken from the class's docstring or overwritten by the keyword
+  argument `description` of `parse_class`.
+* Each method decorated with `create_parser` will become a subparser of its own.
+* The command name of the subparser is the same as the method name with `_` replaced by `-`.
+* 'Private' methods, whose name start with an `_`, do not have a subparser by default, as this would expose them to the
+  outside. However if you want to expose them you can set the keyword argument `parse_private=True` in `parse_class`. If
+  exposed their command name will not contain the leading `-` as this would be confusing for command parsing. Special
+  methods, such as `__str__`, can be decorated as well. Their command name will be stripped of all `_`s resulting in
+  command names such as `str`.
+* When used in a `parse_class` decorated class `create_parser` can take an extra parameters `name` that will be used as
+  the sub-command name. The same modifications are made to the `name` replacing `_` with `-`
+* When calling `python script.py --help` the help message for **every** parser will be displayed making easier to find
+  what you are looking for
 
 
 Arguments and types
 -------------------
 
-Both `parse_this` and `create_parser` need a list of types to which arguments
-will be converted to. Any Python builtin type can be used.
-There is no need to provide a type for keyword arguments since it is inferred
-from the default value of the argument. If your method signature contains
-`arg_with_default=12` `parse_this` expect an `int` where `arg_with_default` is.
+Both `parse_this` and `create_parser` need parameters to have type annotations. Any Python builtin type can be used.
+There is no need to provide a type for keyword arguments since it is inferred from the default value of the argument. If
+your method signature contains `arg_with_default=12` `parse_this` expect an `int` where `arg_with_default` is on the
+command line.
 
 If this is the content of `parse_me.py`:
 
@@ -165,13 +155,12 @@ optional arguments:
                         guess what? I got a default value
 ```
 
-The method `parse_me_if_you_can` expect an `int` with the name `an_int`, a `str`
-with the name `a_string` and other `int` with the name `an_other_int` and a default
-value of 12. So does the parser as displayed by the `--help` command.
+The method `parse_me_if_you_can` expect an `int` with the name `an_int`, a `str` with the name `a_string` and
+other `int` with the name `an_other_int` and a default value of 12. So does the parser as displayed by the `--help`
+command.
 
-Note: `create_parser` cannot decorate the `__init__` method of a class unless
-the class is itself decorated with `parse_class`. A `ParseThisException` will be
-raised if you attempt to use the `call` method of such a parser.
+Note: `create_parser` cannot decorate the `__init__` method of a class unless the class is itself decorated
+with `parse_class`. A `ParseThisException` will be raised if you attempt to use the `call` method of such a parser.
 
 
 The following would be the output of the command line `python parse_me.py 2 yes --default 4`:
@@ -203,27 +192,25 @@ def method(self, spam: int, ham: int):
 
 * description: is a multiline description of the method used for the command line
 * each line of argument help have the following component:
-  * arg_name: the **same** name as the argument of the method.
-  * delimiter_chars: one or more chars that separate the argument and its help
-    message. Using whitespaces is not recommended as it could have an expected
-    behavior with multiline help message.
-  * arg_help: is everything behind the delimiter_chars until the next argument,
-    **a blank line** or the end of the docstring.
+    * arg_name: the **same** name as the argument of the method.
+    * delimiter_chars: one or more chars that separate the argument and its help message. Using whitespaces is not
+      recommended as it could have an expected behavior with multiline help message.
+    * arg_help: is everything behind the delimiter_chars until the next argument, **a blank line** or the end of the
+      docstring.
 
-The `delimiter_chars` can be passed to both `parse_this` and `create_parser` as
-the keywords argument `delimiter_chars`. It defaults to `:` since this is the
-convention I most often use.
+The `delimiter_chars` can be passed to both `parse_this` and `create_parser` as the keywords argument `delimiter_chars`.
+It defaults to `:` since this is the convention I most often use.
 
-If no docstring is specified a generic - not so useful - help message will
-be generated for the command line and arguments.
+If no docstring is specified a generic - not so useful - help message will be generated for the command line and
+arguments.
 
 
 Using None as a default value and bool as flags
 -----------------------------------------------
 
-Using `None` as a default value is common practice in Python but for `parse_this`
-and `create_parser` to work properly the type of the argument which defaults
-to `None` needs to be specified. Otherwise a `ParseThisException` will be raised.
+Using `None` as a default value is common practice in Python but for `parse_this` and `create_parser` to work properly
+the type of the argument which defaults to `None` needs to be specified. Otherwise a `ParseThisException` will be
+raised.
 
 ```python
 from parse_this import create_parser
@@ -255,16 +242,15 @@ def parrot(ham: str, spam: int = None):
 # Calling function.parser.call(args="yes --spam 3".split()) -> 'yesyesyes'
 ```
 
-An other common practice is to use `bool`s as flags or switches. All arguments
-of type `bool`, either typed directly or inferred from the default value, will
-become optional arguments of the command line. A `bool` argument without default
+An other common practice is to use `bool`s as flags or switches. All arguments of type `bool`, either typed directly or
+inferred from the default value, will become optional arguments of the command line. A `bool` argument without default
 value will default to `True` as in the following example:
 
 ```python
 from parse_this import create_parser
 
-@create_parser(str, bool)
-def parrot(ham, spam):
+@create_parser()
+def parrot(ham: str, spam: bool):
   if spam:
     return ham, spam
   return ham
@@ -273,9 +259,8 @@ def parrot(ham, spam):
 # Calling parrot.parser.call(args="yes --spam".split()) -> 'yes'
 ```
 
-Adding `--spam` to the arguments will act as a flag/switch setting `spam` to
-`False`. Note that `spam` as become optional and will be given the value `True`
-if `--spam` is not among the arguments to parse.
+Adding `--spam` to the arguments will act as a flag/switch setting `spam` to `False`. Note that `spam` as become
+optional and will be given the value `True` if `--spam` is not among the arguments to parse.
 
 
 Arguments with a boolean default value will act as a flag to change the default value:
@@ -284,7 +269,7 @@ from parse_this import create_parser
 
 
 @create_parser()
-def parrot(ham: str, spam=False):
+def parrot(ham: str, spam: bool = False):
     if spam:
         return ham, spam
     return ham
@@ -300,9 +285,8 @@ and passing `--spam` as an argument to be parsed will assign it `True`.
 Decorator
 ---------
 
-As a decorator `create_parser` will create an argument parser for the decorated
-function. A `parser` attribute will be added to the method and can be used to
-parse the command line argument.
+As a decorator `create_parser` will create an argument parser for the decorated function. A `parser` attribute will be
+added to the method and can be used to parse the command line argument.
 
 ```python
 from parse_this import create_parser
@@ -323,17 +307,12 @@ if __name__ == "__main__":
     print(concatenate_str.parser.call())
 ```
 
-Calling this script from the command line as follow:
+Calling this script from the command line, `python script.py yes --two 3` will return `'yesyesyes'` as expected and all
+the parsing has been done for you.
 
-```bash
-python script.py yes --two 3
-```
-
-will return `'yesyesyes'` as expected and all the parsing has been done for you.
-
-Note that the function can still be called as any other function from any python
-file. Also it is **not** possible to stack `create_parser` with any decorator that
-would modify the signature of the decorated function e.g. using `functools.wraps`.
+Note that the function can still be called as any other function from any python file. Also it is **not** possible to
+stack `create_parser` with any decorator that would modify the signature of the decorated function e.g.
+using `functools.wraps`.
 
 
 Function
@@ -359,14 +338,13 @@ if __name__ == "__main__":
     print(parse_this(concatenate_str))
 ```
 
-Calling this script with the same command line arguments `yes --two 3` will also
-return `'yesyesyes'` as expected.
+Calling this script with the same command line arguments `yes --two 3` will also return `'yesyesyes'` as expected.
 
 
 Classmethods
 ------------
 
-In a similar fashion you can parse line arguments for classmethods:
+In a similar fashion you can parse command line arguments for classmethods:
 
 ```python
 from parse_this import create_parser
@@ -393,10 +371,11 @@ MyClass.parse_me_if_you_can.parser.call(MyClass)
 The output will be the same as using `create_parser` on a regular method.
 
 **Notes**:
-  * The `classmethod` decorator is placed **on top** of the `create_parser`
-    decorator in order for the method to still be a considered a class method.
-  * A `classmethod` decorated with `create_parser` in a class decorated with `parse_class`
-    will not be accessible through the class command line.
+
+* The `classmethod` decorator is placed **on top** of the `create_parser` decorator in order for the method to still be
+  a considered a class method.
+* A `classmethod` decorated with `create_parser` in a class decorated with `parse_class` will not be accessible through
+  the class command line.
 
 
 Installing `parse_this`
@@ -421,27 +400,17 @@ python -m pip install --upgrade pip && python -m pip install -r requirements.txt
 CAVEATS
 -------
 
- * `parse_this` and `create_parser` are not able to be used on methods with
-   `*args` and `**kwargs`
- * A subsequent effect of the previous caveat is that `create_parser` cannot
-   be stacked with other decorator that would alter the callable's signature
- * Classmethods cannot be access from the command line in a class decorated
-   with `parse_class`
- * When using `create_parser` on a method that has an argument with `None` as
-   a default value its type *must be* past in the list of types. A `ParseThisException`
-   will be raised otherwise.
-
+* `parse_this` and `create_parser` are not able to be used on methods with `*args` and `**kwargs`
+* A subsequent effect of the previous caveat is that `create_parser` cannot be stacked with other decorator that would
+  alter the callable's signature
+* Classmethods cannot be access from the command line in a class decorated with `parse_class`
+* When using `create_parser` on a method that has an argument with `None` as a default value its type *must be* past in
+  the list of types. A `ParseThisException` will be raised otherwise.
 
 TO DO
 -----
-
-  * Code should be moved out of the `parse_this/__init__.py` file and into a
-    specific file. The `__init__` should only be used for imports.
-  * Handle reST formatted docstrings
   * Handle file arguments
-  * Handle list arguments i.e. argparse's nargs.
-  * Python3 version should use the [inspect.Signature][inspect_signature]
-    class instead of inspect.getargspec which will be deprecated in python3.5
+  * Handle list/tuple arguments i.e. argparse's nargs
 
 
 License

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 parse_this
 ==========
 
-[![PyPI latest version badge][pypi_version]][pypi_link]
+[![PyPI latest version badge][pypi_version]][pypi_link] ![supported python versions][python_version]
 
 Makes it easy to parse command line arguments for any function, method or classmethod.
 
@@ -432,4 +432,5 @@ pytest
 
 [pypi_link]: https://pypi.org/project/parse-this/ "parse_this on PyPI"
 [pypi_version]: https://badge.fury.io/py/parse-this.svg "PyPI latest version"
+[python_version]: https://img.shields.io/badge/python-3.8--3.9--3.10-green
 [inspect_signature]: https://docs.python.org/dev/library/inspect.html#inspect.signature

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 parse_this
 ==========
 
-[![PyPI latest version badge][pypi_version]][pypi_link] ![supported python versions][python_version]
+[![PyPI latest version badge][pypi_version]][pypi_link] ![supported python versions][python_version] ![wheel support][wheel_support]
 
 Makes it easy to parse command line arguments for any function, method or classmethod.
 
@@ -432,5 +432,6 @@ pytest
 
 [pypi_link]: https://pypi.org/project/parse-this/ "parse_this on PyPI"
 [pypi_version]: https://badge.fury.io/py/parse-this.svg "PyPI latest version"
-[python_version]: https://img.shields.io/badge/python-3.8--3.9--3.10-green
+[python_version]: https://img.shields.io/pypi/pyversions/parse_this?style=flat-square
+[wheel_support]: https://img.shields.io/pypi/wheel/parse_this?style=flat-square
 [inspect_signature]: https://docs.python.org/dev/library/inspect.html#inspect.signature

--- a/parse_this/__init__.py
+++ b/parse_this/__init__.py
@@ -40,7 +40,7 @@ def parse_this(func, types, args=None, delimiter_chars=":"):
     """
     _LOG.debug("Creating parser for %s", func.__name__)
     (func_args, _, _, defaults, _, _, annotations) = getfullargspec(func)
-    types, func_args = _check_types(func.__name__, types, func_args, defaults)
+    func_args = _check_types(func.__name__, annotations, func_args, defaults)
     args_and_defaults = _get_args_and_defaults(func_args, defaults)
     parser = _get_arg_parser(func, annotations, args_and_defaults, delimiter_chars)
     arguments = parser.parse_args(_get_args_to_parse(args))

--- a/parse_this/__init__.py
+++ b/parse_this/__init__.py
@@ -11,11 +11,8 @@ from parse_this.parsing import (
     _get_arg_parser,
 )
 from parse_this.types import _check_types
-from parse_this.values import Class, Self
 
 __all__ = [
-    "Self",
-    "Class",
     "ParseThisException",
     "parse_this",
     "create_parser",

--- a/parse_this/__init__.py
+++ b/parse_this/__init__.py
@@ -42,9 +42,7 @@ def parse_this(func, types, args=None, delimiter_chars=":"):
     (func_args, _, _, defaults, _, _, annotations) = getfullargspec(func)
     types, func_args = _check_types(func.__name__, types, func_args, defaults)
     args_and_defaults = _get_args_and_defaults(func_args, defaults)
-    parser = _get_arg_parser(
-        func, types, annotations, args_and_defaults, delimiter_chars
-    )
+    parser = _get_arg_parser(func, annotations, args_and_defaults, delimiter_chars)
     arguments = parser.parse_args(_get_args_to_parse(args))
     return _call(func, func_args, arguments)
 

--- a/parse_this/__init__.py
+++ b/parse_this/__init__.py
@@ -23,14 +23,12 @@ __all__ = [
 _LOG = logging.getLogger(__name__)
 
 
-def parse_this(func, types, args=None, delimiter_chars=":"):
+def parse_this(func, args=None, delimiter_chars=":"):
     """Create an ArgParser for the given function converting the command line
        arguments according to the list of types.
 
     Args:
         func: the function for which the command line arguments to be parsed
-        types: a list of types - as accepted by argparse - that will be used to
-            convert the command line arguments
         args: a list of arguments to be parsed if None sys.argv is used
         delimiter_chars: characters used to separate the parameters from their
         help message in the docstring. Defaults to ':'

--- a/parse_this/__init__.py
+++ b/parse_this/__init__.py
@@ -39,10 +39,12 @@ def parse_this(func, types, args=None, delimiter_chars=":"):
         help message in the docstring. Defaults to ':'
     """
     _LOG.debug("Creating parser for %s", func.__name__)
-    (func_args, _, _, defaults, _, _, _) = getfullargspec(func)
+    (func_args, _, _, defaults, _, _, annotations) = getfullargspec(func)
     types, func_args = _check_types(func.__name__, types, func_args, defaults)
     args_and_defaults = _get_args_and_defaults(func_args, defaults)
-    parser = _get_arg_parser(func, types, args_and_defaults, delimiter_chars)
+    parser = _get_arg_parser(
+        func, types, annotations, args_and_defaults, delimiter_chars
+    )
     arguments = parser.parse_args(_get_args_to_parse(args))
     return _call(func, func_args, arguments)
 

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -55,7 +55,7 @@ class MethodParser(object):
             )
             args_and_defaults = _get_args_and_defaults(func_args, defaults)
             parser = _get_arg_parser(
-                func, self._types, annotations, args_and_defaults, self._delimiter_chars
+                func, annotations, args_and_defaults, self._delimiter_chars
             )
             parser.get_name = lambda: self._name
             func.parser = parser

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -50,9 +50,7 @@ class MethodParser(object):
                 "/%s" % self._name if self._name else "",
             )
             (func_args, _, _, defaults, _, _, annotations) = getfullargspec(func)
-            self._types, func_args = _check_types(
-                func.__name__, self._types, func_args, defaults
-            )
+            func_args = _check_types(func.__name__, annotations, func_args, defaults)
             args_and_defaults = _get_args_and_defaults(func_args, defaults)
             parser = _get_arg_parser(
                 func, annotations, args_and_defaults, self._delimiter_chars

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -49,13 +49,14 @@ class MethodParser(object):
                 func.__name__,
                 "/%s" % self._name if self._name else "",
             )
-            (func_args, _, _, defaults, _, _, _) = getfullargspec(func)
+            (func_args, _, _, defaults, _, _, annotations) = getfullargspec(func)
+            _LOG.error(f"{func.__name__} - {getfullargspec(func)}")
             self._types, func_args = _check_types(
                 func.__name__, self._types, func_args, defaults
             )
             args_and_defaults = _get_args_and_defaults(func_args, defaults)
             parser = _get_arg_parser(
-                func, self._types, args_and_defaults, self._delimiter_chars
+                func, self._types, annotations, args_and_defaults, self._delimiter_chars
             )
             parser.get_name = lambda: self._name
             func.parser = parser

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -21,21 +21,17 @@ class MethodParser(object):
         decorated with 'parse_class'
     """
 
-    def __init__(self, *types, **options):
+    def __init__(self, delimiter_chars=":", name=None):
         """
         Args:
-            types: vargs list of types to which the command line arguments
-            should be converted to
-            options: options to pass to create the parser. Possible values are:
-                -delimiter_chars: characters used to separate the parameters
-                from their help message in the docstring. Defaults to ':'
-                -name: name that will be used for the parser when used in a
-                class decorated with `parse_class`. If not provided the name
-                of the method will be used
+            delimiter_chars: characters used to separate the parameters from their
+            help message in the docstring.
+            name: name that will be used for the parser when used in a class
+            decorated with `parse_class`. If not provided the name of the method will
+            be used
         """
-        self._types = types
-        self._delimiter_chars = options.get("delimiter_chars", ":")
-        self._name = options.get("name", None)
+        self._delimiter_chars = delimiter_chars
+        self._name = name
 
     def __call__(self, func):
         """Add an argument parser attribute `parser` to the decorated function.

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -50,7 +50,6 @@ class MethodParser(object):
                 "/%s" % self._name if self._name else "",
             )
             (func_args, _, _, defaults, _, _, annotations) = getfullargspec(func)
-            _LOG.error(f"{func.__name__} - {getfullargspec(func)}")
             self._types, func_args = _check_types(
                 func.__name__, self._types, func_args, defaults
             )

--- a/parse_this/parsing.py
+++ b/parse_this/parsing.py
@@ -41,15 +41,13 @@ def _get_parseable_methods(cls):
     return init_parser, methods_to_parse
 
 
-def _get_arg_parser(func, types, annotations, args_and_defaults, delimiter_chars):
+def _get_arg_parser(func, annotations, args_and_defaults, delimiter_chars):
     """Return an ArgumentParser for the given function. Arguments are defined
         from the function arguments and their associated defaults.
 
     Args:
         func: function for which we want an ArgumentParser
-        types: types to which the command line arguments should be converted to
-        annotations: is a dictionary mapping parameter names to annotations,
-        takes precedence over types
+        annotations: is a dictionary mapping parameter names to annotations
         args_and_defaults: list of 2-tuples (arg_name, arg_default)
         delimiter_chars: characters used to separate the parameters from their
         help message in the docstring

--- a/parse_this/parsing.py
+++ b/parse_this/parsing.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-from itertools import zip_longest
 
 from parse_this.exception import ParseThisException
 from parse_this.help.description import prepare_doc
@@ -60,10 +59,11 @@ def _get_arg_parser(func, types, annotations, args_and_defaults, delimiter_chars
         func, [x for (x, _) in args_and_defaults], delimiter_chars
     )
     parser = argparse.ArgumentParser(description=description)
-    for ((arg, default), arg_type) in zip_longest(args_and_defaults, types):
+    for (arg, default) in args_and_defaults:
         help_msg = arg_help[arg]
+        arg_type = annotations.get(arg)
         if default is _NO_DEFAULT:
-            arg_type = annotations.get(arg) or arg_type or (lambda x: x)
+            arg_type = arg_type or (lambda x: x)
             if arg_type == bool:
                 _LOG.debug("Adding optional flag %s.%s", func.__name__, arg)
                 parser.add_argument(

--- a/parse_this/parsing.py
+++ b/parse_this/parsing.py
@@ -42,13 +42,15 @@ def _get_parseable_methods(cls):
     return init_parser, methods_to_parse
 
 
-def _get_arg_parser(func, types, args_and_defaults, delimiter_chars):
+def _get_arg_parser(func, types, annotations, args_and_defaults, delimiter_chars):
     """Return an ArgumentParser for the given function. Arguments are defined
         from the function arguments and their associated defaults.
 
     Args:
         func: function for which we want an ArgumentParser
         types: types to which the command line arguments should be converted to
+        annotations: is a dictionary mapping parameter names to annotations,
+        takes precedence over types
         args_and_defaults: list of 2-tuples (arg_name, arg_default)
         delimiter_chars: characters used to separate the parameters from their
         help message in the docstring
@@ -61,7 +63,7 @@ def _get_arg_parser(func, types, args_and_defaults, delimiter_chars):
     for ((arg, default), arg_type) in zip_longest(args_and_defaults, types):
         help_msg = arg_help[arg]
         if default is _NO_DEFAULT:
-            arg_type = arg_type or (lambda x: x)
+            arg_type = annotations.get(arg) or arg_type or (lambda x: x)
             if arg_type == bool:
                 _LOG.debug("Adding optional flag %s.%s", func.__name__, arg)
                 parser.add_argument(

--- a/parse_this/types.py
+++ b/parse_this/types.py
@@ -19,7 +19,7 @@ def _check_types(func_name, types, func_args, defaults):
     defaults = defaults or []
     if len(types) > len(func_args):
         raise ParseThisException(
-            "To many types provided for conversion for '{}'.".format(func_name)
+            "Too many types provided for conversion for '{}'.".format(func_name)
         )
     if len(types) < len(func_args) - len(defaults):
         raise ParseThisException(

--- a/parse_this/values.py
+++ b/parse_this/values.py
@@ -1,9 +1,1 @@
 _NO_DEFAULT = object()
-
-
-class Self(object):
-    """Special value to use as the type of the self arg of a method."""
-
-
-class Class(object):
-    """Special value to use as the type of the cls arg of a classmethod."""

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(README_PATH, "r") as README_FILE:
 
 setup(
     name="parse_this",
-    version="2.0.4",
+    version="3.0.0",
     description=(
         "Makes it easy to create a command line interface for any "
         "function, method or classmethod.."

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -288,6 +288,19 @@ class TestCore(unittest.TestCase):
             has_none_default_value.parser.call(args=["12", "--b", "yes"]), (12, "yes")
         )
 
+    def test_get_arg_parser_annotation_take_precedence(self):
+        parser = _get_arg_parser(
+            parse_me_full_docstring,
+            [dict, dict, dict],
+            {"one": int, "two": int, "three": int},
+            [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", _NO_DEFAULT)],
+            ":",
+        )
+        namespace = parser.parse_args("1 2 3".split())
+        self.assertEqual(namespace.one, 1)
+        self.assertEqual(namespace.two, 2)
+        self.assertEqual(namespace.three, 3)
+
     def test_get_arg_parser_with_default_value(self):
         parser = _get_arg_parser(
             parse_me_full_docstring,

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -292,6 +292,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
+            {},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )
@@ -304,6 +305,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
+            {},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )
@@ -316,6 +318,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
+            {},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )
@@ -328,6 +331,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
+            {},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -30,50 +30,50 @@ def with_args(a, b):
 @parse_class()
 class Parseable(object):
     @create_parser(Self, int)
-    def __init__(self, a):
+    def __init__(self, a: int):
         self._a = a
 
     @create_parser(Self, int)
-    def _private_method(self, b):
+    def _private_method(self, b: int):
         return self._a * b
 
-    def not_parseable(self, c):
+    def not_parseable(self, c: int):
         return self._a * c
 
     @create_parser(Self, int)
-    def parseable(self, d):
+    def parseable(self, d: int):
         return self._a * d
 
     @classmethod
     @create_parser(Class, int)
-    def cls_method(cls, e):
+    def cls_method(cls, e: int):
         return e * e
 
 
 @parse_class(parse_private=True)
 class ParseableWithPrivateMethod(object):
     @create_parser(Self, int)
-    def __init__(self, a):
+    def __init__(self, a: int):
         self._a = a
 
     @create_parser(Self, int)
-    def _private_method(self, b):
+    def _private_method(self, b: int):
         return self._a * b
 
-    def not_parseable(self, c):
+    def not_parseable(self, c: int):
         return self._a * c
 
     @create_parser(Self, int)
-    def parseable(self, d):
+    def parseable(self, d: int):
         return self._a * d
 
     @classmethod
     @create_parser(Class, int)
-    def cls_method(cls, e):
+    def cls_method(cls, e: int):
         return e * e
 
 
-def blank_line_in_wrong_place(one, two):
+def blank_line_in_wrong_place(one: int, two: int):
     """I put the blank line after arguments ...
 
     Args:
@@ -84,7 +84,7 @@ def blank_line_in_wrong_place(one, two):
     return one * two
 
 
-def parse_me_full_docstring(one, two, three=12):
+def parse_me_full_docstring(one: int, two: int, three: int = 12):
     """Could use some parsing.
 
     Args:
@@ -99,11 +99,11 @@ def parse_me_full_docstring(one, two, three=12):
     return one * two, three * three
 
 
-def parse_me_no_docstring(one, two, three):
+def parse_me_no_docstring(one: int, two: int, three: int):
     return one * two, three * three
 
 
-def multiline_docstring(one, two, three):
+def multiline_docstring(one: int, two: int, three: int):
     """I am a sneaky function.
 
     Args:
@@ -118,7 +118,7 @@ def multiline_docstring(one, two, three):
     return one * two, three * three
 
 
-def different_delimiter_charsiter(one, two, three):
+def different_delimiter_charsiter(one: int, two: int, three: int):
     """I am a sneaky function.
 
     Args:
@@ -134,22 +134,22 @@ def different_delimiter_charsiter(one, two, three):
 
 
 @create_parser(str, int)
-def concatenate_string(string, nb_concat):
+def concatenate_string(string: str, nb_concat: int):
     return string * nb_concat
 
 
 @create_parser(int, str)
-def has_none_default_value(a, b=None):
+def has_none_default_value(a: int, b: int = None):
     return a, b
 
 
 @create_parser(int)
-def has_flags(a, b=False):
+def has_flags(a: int, b: bool = False):
     return a, b
 
 
 @create_parser(bool)
-def has_bool_arguments(a):
+def has_bool_arguments(a: bool):
     return a
 
 
@@ -279,7 +279,7 @@ class TestCore(unittest.TestCase):
         with self.assertRaises(ParseThisException):
 
             @create_parser(int)
-            def have_none_default_value(a, b=None):
+            def have_none_default_value(a: int, b=None):
                 pass
 
     def test_get_arg_parser_with_none_default_value(self):

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -1,7 +1,7 @@
 import unittest
 from collections import namedtuple
 
-from parse_this import Class, Self, create_parser, parse_class
+from parse_this import create_parser, parse_class
 from parse_this.args import _get_args_and_defaults, _get_args_to_parse
 from parse_this.call import (
     _call,
@@ -29,46 +29,46 @@ def with_args(a, b):
 
 @parse_class()
 class Parseable(object):
-    @create_parser(Self, int)
+    @create_parser()
     def __init__(self, a: int):
         self._a = a
 
-    @create_parser(Self, int)
+    @create_parser()
     def _private_method(self, b: int):
         return self._a * b
 
     def not_parseable(self, c: int):
         return self._a * c
 
-    @create_parser(Self, int)
+    @create_parser()
     def parseable(self, d: int):
         return self._a * d
 
     @classmethod
-    @create_parser(Class, int)
+    @create_parser()
     def cls_method(cls, e: int):
         return e * e
 
 
 @parse_class(parse_private=True)
 class ParseableWithPrivateMethod(object):
-    @create_parser(Self, int)
+    @create_parser()
     def __init__(self, a: int):
         self._a = a
 
-    @create_parser(Self, int)
+    @create_parser()
     def _private_method(self, b: int):
         return self._a * b
 
     def not_parseable(self, c: int):
         return self._a * c
 
-    @create_parser(Self, int)
+    @create_parser()
     def parseable(self, d: int):
         return self._a * d
 
     @classmethod
-    @create_parser(Class, int)
+    @create_parser()
     def cls_method(cls, e: int):
         return e * e
 
@@ -133,22 +133,22 @@ def different_delimiter_charsiter(one: int, two: int, three: int):
     return one * two, three * three
 
 
-@create_parser(str, int)
+@create_parser()
 def concatenate_string(string: str, nb_concat: int):
     return string * nb_concat
 
 
-@create_parser(int, str)
+@create_parser()
 def has_none_default_value(a: int, b: str = None):
     return a, b
 
 
-@create_parser(int)
+@create_parser()
 def has_flags(a: int, b: bool = False):
     return a, b
 
 
-@create_parser(bool)
+@create_parser()
 def has_bool_arguments(a: bool):
     return a
 

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -367,52 +367,66 @@ class TestCore(unittest.TestCase):
 
     def test_check_types_not_enough_types_provided(self):
         self.assertRaises(
-            ParseThisException, _check_types, "function", [], ["i_dont_have_a_type"], ()
+            ParseThisException, _check_types, "function", {}, ["i_dont_have_a_type"], ()
         )
 
     def test_check_types_too_many_types_provided(self):
         self.assertRaises(
-            ParseThisException, _check_types, "function", [int, str], ["i_am_alone"], ()
+            ParseThisException,
+            _check_types,
+            "function",
+            {"a": int, "b": int},
+            ["i_am_alone"],
+            (),
         )
 
     def test_check_types_with_default(self):
-        types = [int, str]
         func_args = ["i_am_alone", "i_have_a_default_value"]
         self.assertEqual(
-            _check_types("function", types, func_args, ("default_value",)),
-            (types, func_args),
+            _check_types(
+                "function",
+                {"i_am_an_int": int, "i_have_a_default_value": str},
+                func_args,
+                ("default_value",),
+            ),
+            func_args,
         )
 
     def test_check_types_with_default_type_not_specified(self):
-        types = [int]
         func_args = ["i_am_an_int", "i_have_a_default_value"]
         self.assertEqual(
-            _check_types("function", types, func_args, ("default_value",)),
-            (types, func_args),
+            _check_types(
+                "function", {"i_am_an_int": int}, func_args, ("default_value",)
+            ),
+            func_args,
         )
 
     def test_check_types_remove_self(self):
-        types = [int]
         func_args = ["i_am_an_int", "i_have_a_default_value"]
         self.assertEqual(
             _check_types(
-                "function", [Self] + types, ["self"] + func_args, ("default_value",)
+                "function",
+                {"i_am_an_int": int},
+                ["self"] + func_args,
+                ("default_value",),
             ),
-            ([int], func_args),
+            func_args,
         )
 
     def test_check_types_remove_class(self):
-        types = [int]
         func_args = ["i_am_an_int", "i_have_a_default_value"]
         self.assertEqual(
             _check_types(
-                "function", [Class] + types, ["cls"] + func_args, ("default_value",)
+                "function",
+                {"i_am_an_int": int},
+                ["cls"] + func_args,
+                ("default_value",),
             ),
-            ([int], func_args),
+            func_args,
         )
 
     def test_check_types_no_args(self):
-        self.assertEqual(_check_types("function", [], [], ()), ([], []))
+        self.assertEqual(_check_types("function", {}, [], ()), [])
 
     def test_get_parser_call_method_returns_callable(self):
         call_method = _get_parser_call_method(concatenate_string)

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -291,7 +291,6 @@ class TestCore(unittest.TestCase):
     def test_get_arg_parser_annotation_take_precedence(self):
         parser = _get_arg_parser(
             parse_me_full_docstring,
-            [dict, dict, dict],
             {"one": int, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", _NO_DEFAULT)],
             ":",
@@ -304,7 +303,6 @@ class TestCore(unittest.TestCase):
     def test_get_arg_parser_with_default_value(self):
         parser = _get_arg_parser(
             parse_me_full_docstring,
-            [str, int],
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
@@ -317,7 +315,6 @@ class TestCore(unittest.TestCase):
     def test_get_arg_parser_without_default_value(self):
         parser = _get_arg_parser(
             parse_me_full_docstring,
-            [str, int],
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
@@ -330,7 +327,6 @@ class TestCore(unittest.TestCase):
     def test_get_arg_parser_required_arguments(self):
         parser = _get_arg_parser(
             parse_me_full_docstring,
-            [str, int],
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
@@ -343,7 +339,6 @@ class TestCore(unittest.TestCase):
     def test_get_arg_parser_argument_type(self):
         parser = _get_arg_parser(
             parse_me_full_docstring,
-            [str, int],
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -118,7 +118,7 @@ def multiline_docstring(one: int, two: int, three: int):
     return one * two, three * three
 
 
-def different_delimiter_charsiter(one: int, two: int, three: int):
+def different_delimiter_chars(one: int, two: int, three: int):
     """I am a sneaky function.
 
     Args:
@@ -254,7 +254,7 @@ class TestCore(unittest.TestCase):
 
     def test_prepare_doc_delimiter_chars(self):
         (description, help_msg) = prepare_doc(
-            different_delimiter_charsiter, ["one", "two", "three"], "--"
+            different_delimiter_chars, ["one", "two", "three"], "--"
         )
         self.assertEqual(description, "I am a sneaky function.")
         self.assertEqual(

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -84,7 +84,7 @@ def blank_line_in_wrong_place(one: int, two: int):
     return one * two
 
 
-def parse_me_full_docstring(one: int, two: int, three: int = 12):
+def parse_me_full_docstring(one: str, two: int, three: int = 12):
     """Could use some parsing.
 
     Args:
@@ -139,7 +139,7 @@ def concatenate_string(string: str, nb_concat: int):
 
 
 @create_parser(int, str)
-def has_none_default_value(a: int, b: int = None):
+def has_none_default_value(a: int, b: str = None):
     return a, b
 
 
@@ -305,7 +305,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
-            {},
+            {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )
@@ -318,7 +318,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
-            {},
+            {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )
@@ -331,7 +331,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
-            {},
+            {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )
@@ -344,7 +344,7 @@ class TestCore(unittest.TestCase):
         parser = _get_arg_parser(
             parse_me_full_docstring,
             [str, int],
-            {},
+            {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
             ":",
         )

--- a/test/parse_this_test.py
+++ b/test/parse_this_test.py
@@ -5,7 +5,7 @@ from parse_this.exception import ParseThisException
 from test.utils import captured_output
 
 
-def parse_me(one, two, three=12):
+def parse_me(one: str, two: int, three: int = 12):
     """Could use some parsing.
 
     Args:
@@ -31,7 +31,7 @@ class TestParseThis(unittest.TestCase):
 
 
 @create_parser(str, int)
-def i_am_parseable(one, two, three=12):
+def i_am_parseable(one: str, two: int, three: int = 12):
     """I too want to be parseable.
 
     Args:
@@ -47,7 +47,7 @@ class Dummy(object):
         self._a = a
 
     @create_parser(Self, int, delimiter_chars="--")
-    def multiply_all(self, b, c=2):
+    def multiply_all(self, b: int, c: int = 2):
         """Will multiply everything!
 
         Args:
@@ -61,13 +61,13 @@ class Dummy(object):
 
     @classmethod
     @create_parser(Class, int)
-    def mult(cls, d, e=2):
+    def mult(cls, d: int, e: int = 2):
         return d * e
 
 
 class NeedParseClassDecorator(object):
     @create_parser(Self, int)
-    def __init__(self, a):
+    def __init__(self, a: int):
         self._a = a
 
 
@@ -97,7 +97,7 @@ class NeedParsing(object):
     """This will be used as the parser description."""
 
     @create_parser(Self, int)
-    def __init__(self, four):
+    def __init__(self, four: int):
         """
         Args:
             four: an int that will be used to multiply stuff
@@ -105,11 +105,11 @@ class NeedParsing(object):
         self._four = four
 
     @create_parser(Self, int)
-    def multiply_self_arg(self, num):
+    def multiply_self_arg(self, num: int):
         return self._four * num
 
     @create_parser(Self, int)
-    def _private_method(self, num):
+    def _private_method(self, num: int):
         return self._four * num
 
     @create_parser(Self)
@@ -117,7 +117,7 @@ class NeedParsing(object):
         return str(self._four)
 
     @create_parser(Self, str, int)
-    def could_you_parse_me(self, one, two, three=12):
+    def could_you_parse_me(self, one: str, two: int, three: int = 12):
         """I would like some arg parsing please.
 
         Args:
@@ -129,7 +129,7 @@ class NeedParsing(object):
 
     @classmethod
     @create_parser(Class, str, int)
-    def parse_me_if_you_can(cls, one, two, three=12):
+    def parse_me_if_you_can(cls, one: str, two: int, three: int = 12):
         return one * two, three * three
 
 
@@ -139,7 +139,7 @@ class ShowMyDocstring(object):
     """This should be the parser description"""
 
     @create_parser(Self, int)
-    def _will_not_appear(self, num):
+    def _will_not_appear(self, num: int):
         return num * num
 
     @create_parser(Self)
@@ -149,11 +149,11 @@ class ShowMyDocstring(object):
 
 @parse_class()
 class NeedInitDecorator(object):
-    def __init__(self, val):
+    def __init__(self, val: int):
         self._val = val
 
     @create_parser(Self, int)
-    def do_stuff(self, num, div=2):
+    def do_stuff(self, num: int, div: int = 2):
         return self._val * num / div
 
 

--- a/test/parse_this_test.py
+++ b/test/parse_this_test.py
@@ -22,12 +22,8 @@ def parse_me(one: str, two: int, three: int = 12):
 
 class TestParseThis(unittest.TestCase):
     def test_parse_this_return_value(self):
-        self.assertEqual(
-            parse_this(parse_me, [str, int], "yes 2".split()), ("yesyes", 144)
-        )
-        self.assertEqual(
-            parse_this(parse_me, [str, int], "no 3 --three 2".split()), ("nonono", 4)
-        )
+        self.assertEqual(parse_this(parse_me, "yes 2".split()), ("yesyes", 144))
+        self.assertEqual(parse_this(parse_me, "no 3 --three 2".split()), ("nonono", 4))
 
 
 @create_parser()

--- a/test/parse_this_test.py
+++ b/test/parse_this_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from parse_this import Class, Self, create_parser, parse_class, parse_this
+from parse_this import create_parser, parse_class, parse_this
 from parse_this.exception import ParseThisException
 from test.utils import captured_output
 
@@ -30,7 +30,7 @@ class TestParseThis(unittest.TestCase):
         )
 
 
-@create_parser(str, int)
+@create_parser()
 def i_am_parseable(one: str, two: int, three: int = 12):
     """I too want to be parseable.
 
@@ -46,7 +46,7 @@ class Dummy(object):
     def __init__(self, a):
         self._a = a
 
-    @create_parser(Self, int, delimiter_chars="--")
+    @create_parser(delimiter_chars="--")
     def multiply_all(self, b: int, c: int = 2):
         """Will multiply everything!
 
@@ -60,13 +60,13 @@ class Dummy(object):
         return self._a * b * c
 
     @classmethod
-    @create_parser(Class, int)
+    @create_parser()
     def mult(cls, d: int, e: int = 2):
         return d * e
 
 
 class NeedParseClassDecorator(object):
-    @create_parser(Self, int)
+    @create_parser()
     def __init__(self, a: int):
         self._a = a
 
@@ -96,7 +96,7 @@ class NeedParsing(object):
 
     """This will be used as the parser description."""
 
-    @create_parser(Self, int)
+    @create_parser()
     def __init__(self, four: int):
         """
         Args:
@@ -104,19 +104,19 @@ class NeedParsing(object):
         """
         self._four = four
 
-    @create_parser(Self, int)
+    @create_parser()
     def multiply_self_arg(self, num: int):
         return self._four * num
 
-    @create_parser(Self, int)
+    @create_parser()
     def _private_method(self, num: int):
         return self._four * num
 
-    @create_parser(Self)
+    @create_parser()
     def __str__(self):
         return str(self._four)
 
-    @create_parser(Self, str, int)
+    @create_parser()
     def could_you_parse_me(self, one: str, two: int, three: int = 12):
         """I would like some arg parsing please.
 
@@ -128,7 +128,7 @@ class NeedParsing(object):
         return one * two, three * three
 
     @classmethod
-    @create_parser(Class, str, int)
+    @create_parser()
     def parse_me_if_you_can(cls, one: str, two: int, three: int = 12):
         return one * two, three * three
 
@@ -138,11 +138,11 @@ class ShowMyDocstring(object):
 
     """This should be the parser description"""
 
-    @create_parser(Self, int)
+    @create_parser()
     def _will_not_appear(self, num: int):
         return num * num
 
-    @create_parser(Self)
+    @create_parser()
     def __str__(self):
         return self.__class__.__name__
 
@@ -152,7 +152,7 @@ class NeedInitDecorator(object):
     def __init__(self, val: int):
         self._val = val
 
-    @create_parser(Self, int)
+    @create_parser()
     def do_stuff(self, num: int, div: int = 2):
         return self._val * num / div
 


### PR DESCRIPTION
By leveraging type annotations we can infer the type of the what the cli args will be mapping to. There is no need for the various decorators to require the user to provide the types.

This also allows me to remove the `Self` and `Class` method TBH were not a nice thing.

This means that only methods that have type annotations can be used.

Tests:
- pytest test OK