### PR TITLE
feat: support Google, NumPy, reST, and Epytext docstring formats

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Quick Reference
 
 * Read the README and follow its instructions
-* All work requiring dependencies must be done inside a virtualenv, source once and maintain that context
 * This repo uses `pre-commit` (ruff, mypy) - you don't need to lint, format, or type-check manually
 
 ## Commands

--- a/.claude/plans/docstring-formats.md
+++ b/.claude/plans/docstring-formats.md
@@ -1,0 +1,339 @@
+# docstring-formats: Support Google, NumPy, reST, and Epytext docstrings
+
+## Context
+
+Today `parse_this/help/description.py` ships a single homemade docstring
+parser. It is a permissive line-based regex
+(`(?P<arg_name>\w+)\s*<delim>\s*(?P<help_msg>.+)`) that effectively
+recognises a Google-ish `Args:` block but with a configurable delimiter
+(`delimiter_chars`, default `:`). It does **not** understand:
+
+- Section headers as boundaries (a stray blank line breaks parsing — see
+  the existing `blank_line_in_wrong_place` fixture, which intentionally
+  loses an arg).
+- NumPy-style underlined `Parameters\n----------` sections.
+- reST/Sphinx `:param name:` directives.
+- Epytext `@param name:` directives.
+- Type fields (`name (int):` Google, `name : int` NumPy, `:type x:` reST).
+
+The user wants `parse_this` to be friendly to projects already documented
+in any of the four mainstream Python docstring styles, without forcing
+authors to rewrite their docstrings just to get a CLI.
+
+The decision (locked via AskUserQuestion in plan mode):
+
+1. **Implementation:** depend on the MIT-licensed `docstring-parser`
+   library — it already handles all four formats and is actively
+   maintained. This becomes the library's first runtime dependency.
+2. **Formats:** support all four — Google, NumPy, reST, Epytext.
+3. **Selection:** auto-detect by default; allow explicit override via a
+   new `docstring_style=` kwarg on the public decorators.
+4. **Backward compat:** fold the legacy custom-delimiter parser into the
+   Google-style parser. The `delimiter_chars=` parameter is removed
+   entirely. **This is a breaking change** for anyone passing a non-`:`
+   delimiter; release as a major version bump.
+
+## Goals
+
+- `parse_this`, `create_parser`, and `parse_class` work out-of-the-box on
+  functions documented in any of the four supported styles.
+- Users can pin a style explicitly with `docstring_style="google"` (or
+  `"numpy"`, `"rest"`, `"epytext"`, `"auto"`) when auto-detection guesses
+  wrong.
+- The argparse `description` and per-argument `help` text are populated
+  from the parsed docstring exactly as today (same return shape from
+  `prepare_doc`).
+- Existing tests for missing/partial docstrings, multiline help, and
+  no-docstring fallback still pass.
+
+## Non-goals
+
+- Type extraction from docstrings — annotations are still the source of
+  truth for converters; we only consume `description` and `arg_name` from
+  the parsed result.
+- Returns / Raises / Yields rendering — argparse has nowhere to put them.
+- Preserving `delimiter_chars` for one release as a deprecation. Per the
+  user's choice, it goes immediately.
+
+## Public API changes
+
+| Symbol | Before | After |
+|---|---|---|
+| `parse_this(func, args=None, delimiter_chars=":", log_level=False, version=None)` | — | `parse_this(func, args=None, docstring_style="auto", log_level=False, version=None)` |
+| `@create_parser(delimiter_chars=":", name=None, log_level=False)` | — | `@create_parser(docstring_style="auto", name=None, log_level=False)` |
+| `@parse_class(...)` | — | unchanged (each method's `@create_parser` carries its own `docstring_style`) |
+| `prepare_doc(func, args, delimiter_chars)` | — | `prepare_doc(func, args, style="auto")` |
+| `_get_arg_parser(..., delimiter_chars, ...)` | — | `_get_arg_parser(..., style, ...)` |
+
+`delimiter_chars` disappears from every signature. Users currently
+relying on a non-`:` delimiter must either rewrite their docstrings to
+use `:` (Google) or migrate to one of the other now-supported styles.
+
+## Style auto-detection
+
+`docstring-parser`'s `parse(docstring)` already auto-detects when called
+without an explicit `style=`. We delegate detection to it. The `"auto"`
+sentinel in our public API maps to `docstring_parser.DocstringStyle.AUTO`.
+
+When `docstring-parser` raises `ParseError` (malformed input that no
+style matches), we fall back to `_get_default_help_message`, the same
+behaviour as today for an empty docstring.
+
+## Implementation tasks (5 atomic commits)
+
+Each commit on the `docstring-formats` branch off a fresh `main`. Stop,
+test, pre-commit, commit between each.
+
+### Commit 1 — `chore: add docstring-parser runtime dependency`
+
+- `pyproject.toml`: add a new top-level `dependencies = ["docstring-parser>=0.16"]`
+  list under `[project]`. The version floor matches the `DocstringStyle`
+  enum spelling we will reference.
+- No code changes; just verifies the dep installs cleanly under
+  `pip install -e .[dev]`.
+
+### Commit 2 — `refactor!: rewrite prepare_doc on docstring-parser, drop delimiter_chars`
+
+This is the load-bearing commit. The legacy regex parser and the
+`delimiter_chars` parameter both disappear in the same change because
+keeping one without the other would leave a phantom argument.
+
+**`parse_this/help/description.py`**
+- Replace the body of `prepare_doc` with a call into `docstring_parser`:
+  ```python
+  from docstring_parser import parse, DocstringStyle, ParseError
+
+  _STYLE_MAP = {
+      "auto":    DocstringStyle.AUTO,
+      "google":  DocstringStyle.GOOGLE,
+      "numpy":   DocstringStyle.NUMPYDOC,
+      "rest":    DocstringStyle.REST,
+      "epytext": DocstringStyle.EPYDOC,
+  }
+
+  def prepare_doc(func, args, style="auto"):
+      if not func.__doc__:
+          return _get_default_help_message(func, args)
+      try:
+          ds_style = _STYLE_MAP[style]
+      except KeyError:
+          raise ParseThisException(
+              f"Unknown docstring_style {style!r}. "
+              f"Expected one of {sorted(_STYLE_MAP)}."
+          )
+      try:
+          parsed = parse(func.__doc__, style=ds_style)
+      except ParseError:
+          return _get_default_help_message(func, args)
+      description = " ".join(
+          p for p in (parsed.short_description, parsed.long_description) if p
+      ) or None
+      args_help = {
+          p.arg_name: p.description
+          for p in parsed.params
+          if p.description
+      }
+      return _get_default_help_message(func, args, description, args_help)
+  ```
+- Keep `_get_default_help_message` exactly as-is — same return shape, same
+  fallback semantics.
+- Drop the `re` import and the regex.
+
+**`parse_this/parsing.py`**
+- `_get_arg_parser`: rename `delimiter_chars: str` to `style: str`, pass it
+  through to `prepare_doc(func, all_arg_names, style)`. Update the
+  docstring.
+
+**`parse_this/parsers.py`**
+- `FunctionParser.__call__`: replace `delimiter_chars: str = ":"` with
+  `docstring_style: str = "auto"`. Pass it to `_get_arg_parser`.
+- `MethodParser.__init__`: replace `delimiter_chars: str = ":"` with
+  `docstring_style: str = "auto"`. Store as `self._docstring_style`.
+- `MethodParser.__call__`: pass `self._docstring_style` to
+  `_get_arg_parser`.
+- `ClassParser`: no signature change — methods carry their own style.
+
+**`test/helpers.py`**
+- Delete `different_delimiter_chars` (the only fixture exercising the
+  removed delimiter behaviour).
+- Delete `blank_line_in_wrong_place` OR rewrite its docstring as a clean
+  Google block — `docstring-parser` will not reproduce the legacy
+  half-broken behaviour the existing test asserts. (Plan: delete it; the
+  test it backs is testing a misfeature.)
+- Keep `parse_me_full_docstring`, `multiline_docstring`, `parse_me`,
+  `parse_me_no_docstring`, `no_docstring`, `with_args` — all are valid
+  Google style and should round-trip cleanly.
+
+**`test/help_test.py`**
+- Delete `test_prepare_doc_blank_line_in_wrong_place` and
+  `test_prepare_doc_delimiter_chars`.
+- Update `test_prepare_doc_full_docstring`,
+  `test_prepare_doc_will_you_dare`, `test_prepare_doc_no_docstring`,
+  and the two `_get_default_help_message` tests to drop the
+  `delimiter_chars` positional argument.
+
+**Other test files**
+- `grep -rn delimiter_chars test/` to find any other call sites and
+  update them.
+
+### Commit 3 — `feat: add docstring_style override and per-format tests`
+
+This commit is purely additive on top of commit 2 — it ships the
+override kwarg's behaviour and the new format support tests. (Commit 2
+already wired the kwarg through; commit 3 proves it works for each
+format end-to-end.)
+
+**`test/docstring_styles_test.py`** (new) — one test class per format,
+each verifying:
+
+- Auto-detection picks the correct style when the docstring uses it.
+- Explicit `docstring_style="<format>"` round-trips description and per-
+  arg help.
+- A function with no docstring still falls back to defaults.
+- A function with a docstring whose `Args`/`Parameters`/`:param` block
+  omits one of the parameters falls back to the default help message
+  for that parameter only.
+
+Per-format fixtures (define inline in the test file, no need to pollute
+`test/helpers.py`):
+
+```python
+def google(one: int, two: str):
+    """Google-style demo.
+
+    Args:
+        one: first value
+        two: second value
+    """
+
+def numpy_(one: int, two: str):
+    """NumPy-style demo.
+
+    Parameters
+    ----------
+    one : int
+        first value
+    two : str
+        second value
+    """
+
+def rest(one: int, two: str):
+    """reST-style demo.
+
+    :param one: first value
+    :param two: second value
+    """
+
+def epytext(one: int, two: str):
+    """Epytext-style demo.
+
+    @param one: first value
+    @param two: second value
+    """
+```
+
+Plus:
+- `test_unknown_style_raises_parse_this_exception` — passing
+  `docstring_style="klingon"` raises `ParseThisException` listing the
+  valid choices.
+- `test_malformed_docstring_falls_back_to_defaults` — feed a docstring
+  that no parser can match (e.g. just a heading underline with no
+  body) and assert default help text is used.
+- `test_create_parser_passes_style_to_prepare_doc` — decorate a function
+  with `@create_parser(docstring_style="numpy")` and assert the parser's
+  per-argument `help` text matches the NumPy block.
+- `test_parse_class_methods_use_their_own_style` — two methods on one
+  `@parse_class`, each decorated with `@create_parser(docstring_style=…)`
+  using a different format; assert both parse correctly.
+
+### Commit 4 — `docs: document docstring format support`
+
+**`README.md`**
+- Replace any reference to `delimiter_chars` (search for the term) with
+  documentation of `docstring_style`.
+- Add a "Docstring formats" subsection under the existing help-text
+  documentation listing the four supported formats with one short
+  example each, and noting auto-detection plus the override kwarg.
+- Add a clear "Breaking changes in v5" callout at the top of the
+  README (or in CHANGELOG if one exists) describing the
+  `delimiter_chars` removal and the migration path (rewrite to `:` or
+  pick another style).
+
+**`pyproject.toml`**
+- Bump `version = "4.0.8"` to `version = "5.0.0"` to signal the breaking
+  change.
+
+### Commit 5 — `chore: add docstring-formats plan file`
+
+- Copy `/Users/bert/.claude/plans/bright-hugging-penguin.md` (this file)
+  to `.claude/plans/docstring-formats.md` in the repo, per the project's
+  workflow rule that plan files are checked in alongside the work they
+  describe.
+
+## Critical files
+
+| File | Change |
+|---|---|
+| `pyproject.toml` | Add `docstring-parser` runtime dep; bump major |
+| `parse_this/help/description.py` | Body of `prepare_doc` rewritten on `docstring-parser`; legacy regex deleted |
+| `parse_this/parsing.py` | `_get_arg_parser` signature: `delimiter_chars` → `style` |
+| `parse_this/parsers.py` | `FunctionParser`, `MethodParser` signatures: `delimiter_chars` → `docstring_style` |
+| `test/help_test.py` | Drop delimiter/blank-line tests; update other calls |
+| `test/helpers.py` | Drop `different_delimiter_chars` and `blank_line_in_wrong_place` fixtures |
+| `test/docstring_styles_test.py` (new) | Per-format coverage |
+| `README.md` | Document `docstring_style`, breaking-change notice |
+| `.claude/plans/docstring-formats.md` (new) | Checked-in plan file |
+
+## Reused functions
+
+- `_get_default_help_message` in `parse_this/help/description.py` — kept
+  verbatim. New `prepare_doc` calls it for both the no-docstring and
+  partial-docstring cases.
+- `ParseThisException` in `parse_this/exception.py` — used for the
+  unknown-style error.
+
+## Verification
+
+1. **Unit tests:** `pytest` — all tests, including the new
+   `test/docstring_styles_test.py`, must pass; 99% coverage gate must
+   stay green (currently set in `pyproject.toml`).
+2. **Pre-commit:** `pre-commit run --all-files` — ruff and mypy clean.
+3. **Manual smoke test:** in a scratch script, decorate the same
+   function written in each of the four styles and confirm
+   `script.py --help` shows the correct per-argument help in each case.
+4. **Manual override test:** decorate a Google-style function with
+   `@create_parser(docstring_style="numpy")` and confirm the help text
+   falls back to `Help message for <arg>` defaults (mismatched style
+   should not match args).
+5. **Manual breaking-change test:** confirm that an old call like
+   `@create_parser(delimiter_chars="--")` raises `TypeError: unexpected
+   keyword argument 'delimiter_chars'` — i.e. the removal is loud, not
+   silent.
+
+## Risk
+
+Medium-high. The breaking change is the biggest risk — anyone depending
+on `delimiter_chars` will see decoration-time `TypeError`s. Mitigation:
+the v5.0.0 bump in pyproject signals the break loudly, and the README
+"Breaking changes" callout in commit 4 documents the migration. The
+`docstring-parser` dependency is small, MIT-licensed, ~140M downloads/
+month, but introduces a supply-chain surface that did not exist before;
+acceptable trade for ~150 LOC of bespoke regex deleted.
+
+## Workflow
+
+This work **stacks** on top of `varargs-kwargs-handling` (the in-flight
+varargs PR), not `main`. The four prior PRs (#49-52) were stacked and
+this one continues that chain.
+
+1. Fetch latest: `git fetch origin`.
+2. From the tip of the stack: `git checkout varargs-kwargs-handling &&
+   git pull`.
+3. Branch off it: `git checkout -b docstring-formats`.
+4. Activate venv, `pip install -e .[dev]`, then install
+   `docstring-parser` (the new dep). Run `pytest` once before changes
+   to confirm baseline green.
+5. Implement commit 1 → test → commit. Repeat for commits 2-5.
+6. Open PR with `--base varargs-kwargs-handling` so it targets the
+   parent branch in the stack. Retarget to `main` once
+   `varargs-kwargs-handling` merges. Link this plan in the PR body.

--- a/README.md
+++ b/README.md
@@ -439,63 +439,19 @@ def greet(name: str, count: int = 1):
     ...
 ```
 
-### NumPy style
+The other supported styles are:
 
-```python
-@create_parser()
-def greet(name: str, count: int = 1):
-    """Greet someone.
-
-    Parameters
-    ----------
-    name : str
-        who to greet
-    count : int
-        how many times to repeat the greeting
-    """
-    ...
-```
-
-### reStructuredText / Sphinx style
-
-```python
-@create_parser()
-def greet(name: str, count: int = 1):
-    """Greet someone.
-
-    :param name: who to greet
-    :param count: how many times to repeat the greeting
-    """
-    ...
-```
-
-### Epytext style
-
-```python
-@create_parser()
-def greet(name: str, count: int = 1):
-    """Greet someone.
-
-    @param name: who to greet
-    @param count: how many times to repeat the greeting
-    """
-    ...
-```
+* [**NumPy style**](https://numpydoc.readthedocs.io/en/latest/format.html)
+* [**reStructuredText / Sphinx style**](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html)
+* [**Epytext style**](https://epydoc.sourceforge.net/manual-epytext.html)
 
 ### Forcing a specific style
+
+If auto-detection guesses wrong, lock the style explicitly:
 
 ```python
 @create_parser(docstring_style="numpy")
 def greet(name: str, count: int = 1):
-    """Greet someone.
-
-    Parameters
-    ----------
-    name : str
-        who to greet
-    count : int
-        how many times to repeat the greeting
-    """
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,22 @@ Installation
 pip install parse_this
 ```
 
-`parse_this` has no runtime dependencies and supports Python 3.10+.
+`parse_this` depends on [`docstring-parser`][docstring_parser] for reading
+Google, NumPy, reST, and Epytext docstrings. It supports Python 3.10+.
+
+> **Breaking changes in v5.0.0**
+>
+> The `delimiter_chars=` parameter has been removed from `parse_this`,
+> `@create_parser`, and `@parse_class`. Argument help is now extracted by
+> [`docstring-parser`][docstring_parser], which natively understands
+> Google, NumPy, reST, and Epytext styles. Auto-detection picks the right
+> one for each function; pass `docstring_style="google"` (or `"numpy"`,
+> `"rest"`, `"epytext"`) to force a specific style. If you previously
+> relied on a non-`:` delimiter, rewrite your docstring in any of the
+> four supported styles. See [Writing docstrings for help
+> messages](#writing-docstrings-for-help-messages).
+
+[docstring_parser]: https://pypi.org/project/docstring-parser/
 
 
 Quick start
@@ -352,14 +367,14 @@ from parse_this import create_parser
 class MyClass(object):
 
     @classmethod
-    @create_parser(delimiter_chars="--")
+    @create_parser()
     def parse_me_if_you_can(cls, an_int: int, a_string: str, default: int = 12):
         """I dare you to parse me !!!
 
         Args:
-            an_int -- int are pretty cool
-            a_string -- string aren't that nice
-            default -- guess what I got a default value
+            an_int: int are pretty cool
+            a_string: string aren't that nice
+            default: guess what I got a default value
         """
         return a_string * an_int, default * default
 
@@ -407,48 +422,94 @@ Writing docstrings for help messages
 ------------------------------------
 
 `parse_this` reads the docstring of your function/method to generate the
-description and per-argument help messages displayed by `--help`. The expected
-format is:
+parser description and per-argument help text displayed by `--help`. Parsing
+is delegated to [`docstring-parser`][docstring_parser], which natively
+understands the four mainstream Python docstring styles: **Google**,
+**NumPy**, **reStructuredText / Sphinx**, and **Epytext**.
+
+By default the style is auto-detected per function — write your docstring in
+whichever style your project already uses and it just works. If detection
+guesses wrong, pass `docstring_style="<style>"` to lock it explicitly. The
+accepted values are `"auto"` (default), `"google"`, `"numpy"`, `"rest"`,
+and `"epytext"`. The kwarg is accepted by `parse_this`, `@create_parser`,
+and (per-method) inside `@parse_class`.
+
+If you don't provide a docstring at all, `parse_this` falls back to a
+generic — and not very useful — help message.
+
+### Google style
 
 ```python
 @create_parser()
-def method(self, spam: int, ham: int):
-    """<description>
-
-      <arg_name><delimiter_chars><arg_help>
-      <arg_name><delimiter_chars><arg_help>
-    """
-    pass
-```
-
-* **description**: a free-form (possibly multiline) description of the
-  function. Used as the parser description.
-* **argument lines**: each line has the form `name<delimiter>help text`. The
-  name must match a parameter of the function. Whitespace around the delimiter
-  is allowed (`spam: help` and `spam : help` both work). Help can span multiple
-  lines (continuation lines are joined) until the next argument line, a blank
-  line, or the end of the docstring.
-
-The default delimiter is `:` (a single colon). To use a different one — for
-example `--`, which avoids ambiguity with type annotation colons — pass
-`delimiter_chars`:
-
-```python
-@create_parser(delimiter_chars="--")
-def parse_me_if_you_can(self, an_int: int, a_string: str, default: int = 12):
-    """I dare you to parse me !!!
+def greet(name: str, count: int = 1):
+    """Greet someone.
 
     Args:
-        an_int -- int are pretty cool
-        a_string -- string aren't that nice
-        default -- guess what I got a default value
+        name: who to greet
+        count: how many times to repeat the greeting
     """
     ...
 ```
 
-`delimiter_chars` is accepted by `parse_this`, `@create_parser`, and
-`@parse_class`. If you don't provide a docstring at all, a generic — and
-not very useful — help message is generated.
+### NumPy style
+
+```python
+@create_parser()
+def greet(name: str, count: int = 1):
+    """Greet someone.
+
+    Parameters
+    ----------
+    name : str
+        who to greet
+    count : int
+        how many times to repeat the greeting
+    """
+    ...
+```
+
+### reStructuredText / Sphinx style
+
+```python
+@create_parser()
+def greet(name: str, count: int = 1):
+    """Greet someone.
+
+    :param name: who to greet
+    :param count: how many times to repeat the greeting
+    """
+    ...
+```
+
+### Epytext style
+
+```python
+@create_parser()
+def greet(name: str, count: int = 1):
+    """Greet someone.
+
+    @param name: who to greet
+    @param count: how many times to repeat the greeting
+    """
+    ...
+```
+
+### Forcing a specific style
+
+```python
+@create_parser(docstring_style="numpy")
+def greet(name: str, count: int = 1):
+    """Greet someone.
+
+    Parameters
+    ----------
+    name : str
+        who to greet
+    count : int
+        how many times to repeat the greeting
+    """
+    ...
+```
 
 
 Argument types

--- a/README.md
+++ b/README.md
@@ -39,18 +39,6 @@ pip install parse_this
 `parse_this` depends on [`docstring-parser`][docstring_parser] for reading
 Google, NumPy, reST, and Epytext docstrings. It supports Python 3.10+.
 
-> **Breaking changes in v5.0.0**
->
-> The `delimiter_chars=` parameter has been removed from `parse_this`,
-> `@create_parser`, and `@parse_class`. Argument help is now extracted by
-> [`docstring-parser`][docstring_parser], which natively understands
-> Google, NumPy, reST, and Epytext styles. Auto-detection picks the right
-> one for each function; pass `docstring_style="google"` (or `"numpy"`,
-> `"rest"`, `"epytext"`) to force a specific style. If you previously
-> relied on a non-`:` delimiter, rewrite your docstring in any of the
-> four supported styles. See [Writing docstrings for help
-> messages](#writing-docstrings-for-help-messages).
-
 [docstring_parser]: https://pypi.org/project/docstring-parser/
 
 

--- a/parse_this/help/description.py
+++ b/parse_this/help/description.py
@@ -1,8 +1,22 @@
 import logging
-import re
 from typing import Callable, Dict, List, Optional, Tuple
 
+from docstring_parser import DocstringStyle, ParseError, parse
+
+from parse_this.exception import ParseThisException
+
 _LOG = logging.getLogger(__name__)
+
+# Public-facing names map to docstring_parser's enum. ``"auto"`` defers
+# detection to docstring_parser, which sniffs Google/NumPy/reST/Epytext
+# from the docstring's structure.
+_STYLE_MAP: Dict[str, DocstringStyle] = {
+    "auto": DocstringStyle.AUTO,
+    "google": DocstringStyle.GOOGLE,
+    "numpy": DocstringStyle.NUMPYDOC,
+    "rest": DocstringStyle.REST,
+    "epytext": DocstringStyle.EPYDOC,
+}
 
 
 def _get_default_help_message(
@@ -33,8 +47,18 @@ def _get_default_help_message(
     return description, args_help
 
 
+def _collapse_whitespace(text: str) -> str:
+    """Collapse runs of whitespace (including newlines) into single spaces.
+
+    docstring_parser preserves multiline parameter descriptions with
+    embedded newlines. argparse's ``help`` field expects a single line, so
+    flatten any continuation lines into one space-joined string.
+    """
+    return " ".join(text.split())
+
+
 def prepare_doc(
-    func: Callable, args: List[str], delimiter_chars: str
+    func: Callable, args: List[str], style: str = "auto"
 ) -> Tuple[str, Dict[str, str]]:
     """From the function docstring get the arg parse description and arguments
         help message. If there is no docstring simple description and help
@@ -43,8 +67,8 @@ def prepare_doc(
     Args:
         func: the function that needs argument parsing
         args: name of the function arguments
-        delimiter_chars: characters used to separate the parameters from their
-        help message in the docstring
+        style: docstring style hint. One of ``"auto"`` (default,
+        autodetect), ``"google"``, ``"numpy"``, ``"rest"``, ``"epytext"``.
 
     Returns:
         A tuple containing the description to be used in the argument parser and
@@ -54,34 +78,25 @@ def prepare_doc(
     _LOG.debug("Preparing doc for '%s'", func.__name__)
     if not func.__doc__:
         return _get_default_help_message(func, args)
-    description = []
-    args_help = {}
-    fill_description = True
-    arg_name = None
-    arg_doc_regex = re.compile(
-        r"(?P<arg_name>\w+)\s*%s\s*(?P<help_msg>.+)" % delimiter_chars
-    )
-    for line in func.__doc__.splitlines():
-        line = line.strip()
-        if line and fill_description:
-            description.append(line)
-        elif line:
-            arg_match = arg_doc_regex.match(line)
-            try:
-                arg_name = arg_match.groupdict()["arg_name"].strip()
-                args_help[arg_name] = arg_match.groupdict()["help_msg"].strip()
-            except AttributeError:
-                # The line didn't match the pattern we've hit a
-                # multiline argument docstring so we add it to the
-                # previous argument help message
-                if arg_name is not None:
-                    args_help[arg_name] = " ".join([args_help[arg_name], line])
-        else:
-            # The first empty line we encountered means we are done with
-            # the description. The first empty line we encounter after
-            # filling the argument help means we are done with argument
-            # parsing.
-            if not fill_description and args_help:
-                break
-            fill_description = False
-    return _get_default_help_message(func, args, " ".join(description), args_help)
+    try:
+        ds_style = _STYLE_MAP[style]
+    except KeyError:
+        raise ParseThisException(
+            f"Unknown docstring_style {style!r}. Expected one of {sorted(_STYLE_MAP)}."
+        )
+    try:
+        parsed = parse(func.__doc__, style=ds_style)
+    except ParseError:
+        # Malformed docstring that no style understood — fall back to
+        # auto-generated defaults rather than crashing decoration.
+        return _get_default_help_message(func, args)
+    description_parts = [
+        part for part in (parsed.short_description, parsed.long_description) if part
+    ]
+    description = _collapse_whitespace(" ".join(description_parts)) or None
+    args_help = {
+        param.arg_name: _collapse_whitespace(param.description)
+        for param in parsed.params
+        if param.description
+    }
+    return _get_default_help_message(func, args, description, args_help)

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -56,7 +56,7 @@ class FunctionParser(object):
         self,
         func: Callable,
         args: typing.List[str] = None,
-        delimiter_chars: str = ":",
+        docstring_style: str = "auto",
         log_level: bool = False,
         version: Optional[str] = None,
     ):
@@ -67,8 +67,9 @@ class FunctionParser(object):
         Args:
             func: the function for which the command line arguments to be parsed
             args: a list of arguments to be parsed if None sys.argv is used
-            delimiter_chars: characters used to separate the parameters from their
-            help message in the docstring. Defaults to ':'
+            docstring_style: which docstring style to parse for the parser
+            description and per-argument help. One of ``"auto"`` (default,
+            autodetect), ``"google"``, ``"numpy"``, ``"rest"``, ``"epytext"``.
             log_level: indicate whether or not a '--log-level' argument should be
             handled to set the log level during the execution
             version: optional version string to enable a '--version' flag.
@@ -82,7 +83,7 @@ class FunctionParser(object):
         func_args = _check_types(func.__name__, annotations, func_args, defaults)
         args_and_defaults = _get_args_and_defaults(func_args, defaults)
         parser = _get_arg_parser(
-            func, annotations, args_and_defaults, delimiter_chars, log_level
+            func, annotations, args_and_defaults, docstring_style, log_level
         )
         if version is not None:
             parser.add_argument("--version", action="version", version=version)
@@ -104,23 +105,27 @@ class MethodParser(object):
     """
 
     _name: Optional[str]
-    _delimiter_chars: str
+    _docstring_style: str
     _log_level: bool
 
     def __init__(
-        self, delimiter_chars: str = ":", name: str = None, log_level: bool = False
+        self,
+        docstring_style: str = "auto",
+        name: str = None,
+        log_level: bool = False,
     ):
         """
         Args:
-            delimiter_chars: characters used to separate the parameters from their
-            help message in the docstring.
+            docstring_style: which docstring style to parse for the parser
+            description and per-argument help. One of ``"auto"`` (default,
+            autodetect), ``"google"``, ``"numpy"``, ``"rest"``, ``"epytext"``.
             name: name that will be used for the parser when used in a class
             decorated with `parse_class`. If not provided the name of the method will
             be used
             log_level: indicate whether or not a '--log-level' argument should be
             handled to set the log level during the execution
         """
-        self._delimiter_chars = delimiter_chars
+        self._docstring_style = docstring_style
         self._name = name
         self._log_level = log_level
 
@@ -147,7 +152,7 @@ class MethodParser(object):
                 func,
                 annotations,
                 args_and_defaults,
-                self._delimiter_chars,
+                self._docstring_style,
                 self._log_level,
             )
             parser.get_name = lambda: self._name or func.__name__  # type: ignore[attr-defined]

--- a/parse_this/parsing.py
+++ b/parse_this/parsing.py
@@ -65,7 +65,7 @@ def _get_arg_parser(
     func: Callable,
     annotations: Dict[str, Callable],
     args_and_defaults: List[Tuple[str, Any]],
-    delimiter_chars: str,
+    docstring_style: str,
     log_level: bool = False,
 ) -> ArgumentParser:
     """Return an ArgumentParser for the given function. Arguments are defined
@@ -75,14 +75,14 @@ def _get_arg_parser(
         func: function for which we want an ArgumentParser
         annotations: is a dictionary mapping parameter names to annotations
         args_and_defaults: list of 2-tuples (arg_name, arg_default)
-        delimiter_chars: characters used to separate the parameters from their
-        help message in the docstring
+        docstring_style: docstring style hint passed to ``prepare_doc``
+        ("auto", "google", "numpy", "rest", "epytext")
         log_level: indicate whether or not a '--log-level' argument should be
         handled to set the log level during the execution
     """
     _LOG.debug("Creating ArgumentParser for '%s'", func.__name__)
     description, arg_help = prepare_doc(
-        func, [x for (x, _) in args_and_defaults], delimiter_chars
+        func, [x for (x, _) in args_and_defaults], docstring_style
     )
     parser = ArgumentParser(description=description)
     if log_level:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ requires-python = ">=3.10"
 authors = [
     { name = "Bertrand Vidal", email = "vidal.bertrand@gmail.com" },
 ]
+dependencies = [
+    "docstring-parser>=0.16",
+]
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "parse_this"
-version = "5.0.0"
+version = "4.0.8"
 description = "Makes it easy to create a command line interface for any function, method or classmethod."
 readme = "README.md"
 license = "MIT"

--- a/test/docstring_styles_test.py
+++ b/test/docstring_styles_test.py
@@ -1,0 +1,227 @@
+"""End-to-end coverage for the four supported docstring styles.
+
+Each style has a fixture function carrying a description plus per-arg
+help written in that style. We exercise both auto-detection (the
+default) and explicit overrides via the ``docstring_style`` kwarg, and
+make sure the parser falls back gracefully on unknown styles and
+unparseable docstrings.
+"""
+
+import unittest
+
+from parse_this import create_parser, parse_class
+from parse_this.exception import ParseThisException
+from parse_this.help.description import prepare_doc
+
+
+def google(one: int, two: str):
+    """Google-style demo.
+
+    Args:
+        one: first value
+        two: second value
+    """
+    return one, two
+
+
+def numpy_doc(one: int, two: str):
+    """NumPy-style demo.
+
+    Parameters
+    ----------
+    one : int
+        first value
+    two : str
+        second value
+    """
+    return one, two
+
+
+def rest(one: int, two: str):
+    """reST-style demo.
+
+    :param one: first value
+    :param two: second value
+    """
+    return one, two
+
+
+def epytext(one: int, two: str):
+    """Epytext-style demo.
+
+    @param one: first value
+    @param two: second value
+    """
+    return one, two
+
+
+def google_partial(one: int, two: str):
+    """Google-style demo with a missing arg.
+
+    Args:
+        one: first value
+    """
+    return one, two
+
+
+class TestAutoDetection(unittest.TestCase):
+    def test_google_autodetect(self):
+        description, help_msg = prepare_doc(google, ["one", "two"])
+        self.assertEqual(description, "Google-style demo.")
+        self.assertEqual(help_msg, {"one": "first value", "two": "second value"})
+
+    def test_numpy_autodetect(self):
+        description, help_msg = prepare_doc(numpy_doc, ["one", "two"])
+        self.assertEqual(description, "NumPy-style demo.")
+        self.assertEqual(help_msg, {"one": "first value", "two": "second value"})
+
+    def test_rest_autodetect(self):
+        description, help_msg = prepare_doc(rest, ["one", "two"])
+        self.assertEqual(description, "reST-style demo.")
+        self.assertEqual(help_msg, {"one": "first value", "two": "second value"})
+
+    def test_epytext_autodetect(self):
+        description, help_msg = prepare_doc(epytext, ["one", "two"])
+        self.assertEqual(description, "Epytext-style demo.")
+        self.assertEqual(help_msg, {"one": "first value", "two": "second value"})
+
+
+class TestExplicitStyleOverride(unittest.TestCase):
+    def test_explicit_google(self):
+        _, help_msg = prepare_doc(google, ["one", "two"], style="google")
+        self.assertEqual(help_msg["one"], "first value")
+
+    def test_explicit_numpy(self):
+        _, help_msg = prepare_doc(numpy_doc, ["one", "two"], style="numpy")
+        self.assertEqual(help_msg["one"], "first value")
+
+    def test_explicit_rest(self):
+        _, help_msg = prepare_doc(rest, ["one", "two"], style="rest")
+        self.assertEqual(help_msg["one"], "first value")
+
+    def test_explicit_epytext(self):
+        _, help_msg = prepare_doc(epytext, ["one", "two"], style="epytext")
+        self.assertEqual(help_msg["one"], "first value")
+
+
+class TestPartialDocstring(unittest.TestCase):
+    def test_missing_param_falls_back_to_default_for_that_arg_only(self):
+        description, help_msg = prepare_doc(google_partial, ["one", "two"])
+        self.assertEqual(description, "Google-style demo with a missing arg.")
+        self.assertEqual(help_msg["one"], "first value")
+        self.assertEqual(help_msg["two"], "Help message for two")
+
+
+class TestErrorHandling(unittest.TestCase):
+    def test_unknown_style_raises_parse_this_exception(self):
+        with self.assertRaises(ParseThisException) as ctx:
+            prepare_doc(google, ["one", "two"], style="klingon")
+        msg = str(ctx.exception)
+        self.assertIn("klingon", msg)
+        # Error lists every supported style so users know what's valid.
+        for valid in ("auto", "google", "numpy", "rest", "epytext"):
+            self.assertIn(valid, msg)
+
+    def test_malformed_docstring_falls_back_to_defaults(self):
+        # docstring_parser raises ParseError on a stray "::" outside of
+        # any valid directive when forced into the reST parser. We use
+        # the explicit "rest" style so auto-detect can't sneak past it.
+        def broken(one: int):
+            """Bad rest.
+
+            :: this is wrong syntax
+            :param: missing name
+            """
+
+        description, help_msg = prepare_doc(broken, ["one"], style="rest")
+        # Decoration must not crash; the help dict should fall back to
+        # the default per-arg messages produced by _get_default_help_message.
+        self.assertEqual(description, "Argument parsing for broken")
+        self.assertEqual(help_msg, {"one": "Help message for one"})
+
+
+class TestDocstringStyleKwargFlow(unittest.TestCase):
+    def test_create_parser_passes_style_to_prepare_doc(self):
+        @create_parser(docstring_style="numpy")
+        def numpy_target(one: int, two: str):
+            """NumPy demo.
+
+            Parameters
+            ----------
+            one : int
+                first value
+            two : str
+                second value
+            """
+            return one, two
+
+        parser = numpy_target.parser
+        self.assertEqual(parser.description, "NumPy demo.")
+        actions_by_dest = {a.dest: a for a in parser._actions}
+        self.assertEqual(actions_by_dest["one"].help, "first value")
+        self.assertEqual(actions_by_dest["two"].help, "second value")
+
+    def test_create_parser_explicit_style_mismatch_falls_back(self):
+        # Decorating a Google-style docstring with style="numpy" should
+        # leave the per-arg help as defaults — docstring_parser cannot
+        # extract Args: blocks via the NumPy parser.
+        @create_parser(docstring_style="numpy")
+        def google_target(one: int, two: str):
+            """Google demo.
+
+            Args:
+                one: first value
+                two: second value
+            """
+            return one, two
+
+        actions_by_dest = {a.dest: a for a in google_target.parser._actions}
+        self.assertEqual(actions_by_dest["one"].help, "Help message for one")
+        self.assertEqual(actions_by_dest["two"].help, "Help message for two")
+
+    def test_parse_class_methods_use_their_own_style(self):
+        @parse_class()
+        class Mixed(object):
+            """A class with two methods documented in two styles."""
+
+            @create_parser(docstring_style="google")
+            def __init__(self, base: int):
+                """Init.
+
+                Args:
+                    base: starting value
+                """
+                self._base = base
+
+            @create_parser(docstring_style="numpy")
+            def add(self, n: int):
+                """NumPy add.
+
+                Parameters
+                ----------
+                n : int
+                    value to add
+                """
+                return self._base + n
+
+            @create_parser(docstring_style="rest")
+            def mul(self, n: int):
+                """reST mul.
+
+                :param n: value to multiply
+                """
+                return self._base * n
+
+        add_parser = Mixed.add.parser
+        mul_parser = Mixed.mul.parser
+        add_actions = {a.dest: a for a in add_parser._actions}
+        mul_actions = {a.dest: a for a in mul_parser._actions}
+        self.assertEqual(add_actions["n"].help, "value to add")
+        self.assertEqual(mul_actions["n"].help, "value to multiply")
+        # End-to-end dispatch using the top-level class parser.
+        self.assertEqual(Mixed.parser.call("10 add 5".split()), 15)
+        self.assertEqual(Mixed.parser.call("10 mul 5".split()), 50)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/help_test.py
+++ b/test/help_test.py
@@ -4,8 +4,6 @@ from parse_this.help.description import _get_default_help_message, prepare_doc
 from test.helpers import (
     Parseable,
     ParseableWithPrivateMethod,
-    blank_line_in_wrong_place,
-    different_delimiter_chars,
     multiline_docstring,
     no_docstring,
     parse_me_full_docstring,
@@ -29,18 +27,9 @@ class TestHelp(unittest.TestCase):
         )
         self.assertListEqual(sorted(list(args_help.keys())), ["a", "b"])
 
-    def test_prepare_doc_blank_line_in_wrong_place(self):
-        description, help_msg = prepare_doc(
-            blank_line_in_wrong_place, ["one", "two"], ":"
-        )
-        self.assertEqual(description, "I put the blank line after arguments ...")
-        self.assertEqual(
-            help_msg, {"one": "this help is #1", "two": "Help message for two"}
-        )
-
     def test_prepare_doc_full_docstring(self):
         description, help_msg = prepare_doc(
-            parse_me_full_docstring, ["one", "two", "three"], ":"
+            parse_me_full_docstring, ["one", "two", "three"]
         )
         self.assertEqual(description, "Could use some parsing.")
         self.assertEqual(
@@ -54,7 +43,7 @@ class TestHelp(unittest.TestCase):
 
     def test_prepare_doc_no_docstring(self):
         description, help_msg = prepare_doc(
-            parse_me_no_docstring, ["one", "two", "three"], ":"
+            parse_me_no_docstring, ["one", "two", "three"]
         )
         self.assertEqual(description, "Argument parsing for parse_me_no_docstring")
         self.assertEqual(
@@ -68,28 +57,13 @@ class TestHelp(unittest.TestCase):
 
     def test_prepare_doc_will_you_dare(self):
         description, help_msg = prepare_doc(
-            multiline_docstring, ["one", "two", "three"], ":"
+            multiline_docstring, ["one", "two", "three"]
         )
         self.assertEqual(description, "I am a sneaky function.")
         self.assertEqual(
             help_msg,
             {
                 "one": "this one is a no brainer",
-                "two": "Help message for two",
-                "three": "noticed you're missing docstring for two and "
-                + "I'm multiline too!",
-            },
-        )
-
-    def test_prepare_doc_delimiter_chars(self):
-        description, help_msg = prepare_doc(
-            different_delimiter_chars, ["one", "two", "three"], "--"
-        )
-        self.assertEqual(description, "I am a sneaky function.")
-        self.assertEqual(
-            help_msg,
-            {
-                "one": "this one is a no brainer even with dashes",
                 "two": "Help message for two",
                 "three": "noticed you're missing docstring for two and "
                 + "I'm multiline too!",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -17,17 +17,6 @@ def with_args(a, b):
     pass
 
 
-def blank_line_in_wrong_place(one: int, two: int):
-    """I put the blank line after arguments ...
-
-    Args:
-        one: this help is #1
-
-        two: this once won't appear sadly
-    """
-    return one * two
-
-
 def parse_me_full_docstring(one: str, two: int, three: int = 12):
     """Could use some parsing.
 
@@ -53,21 +42,6 @@ def multiline_docstring(one: int, two: int, three: int):
     Args:
         one: this one is a no brainer
         three: noticed you're missing docstring for two and
-          I'm multiline too!
-
-    Returns:
-        the first string argument concatenated with itself 'two' times and the
-        last parameters multiplied by itself
-    """
-    return one * two, three * three
-
-
-def different_delimiter_chars(one: int, two: int, three: int):
-    """I am a sneaky function.
-
-    Args:
-        one -- this one is a no brainer even with dashes
-        three -- noticed you're missing docstring for two and
           I'm multiline too!
 
     Returns:
@@ -190,13 +164,13 @@ class Dummy(object):
     def __init__(self, a):
         self._a = a
 
-    @create_parser(delimiter_chars="--")
+    @create_parser()
     def multiply_all(self, b: int, c: int = 2):
         """Will multiply everything!
 
         Args:
-            b -- the Queen B
-            c -- a useless value
+            b: the Queen B
+            c: a useless value
 
         Returns:
             Everything multiplied

--- a/test/parsers_test.py
+++ b/test/parsers_test.py
@@ -15,7 +15,6 @@ from test.helpers import (
     ParseableWithLogLevel,
     ShowMyDocstring,
     SubCmdParseError,
-    different_delimiter_chars,
     function_with_log_level,
     i_am_parseable,
     parse_me_full_docstring,
@@ -36,27 +35,6 @@ class TestFunctionParser(unittest.TestCase):
         actual = parser(parse_me_full_docstring, "first 2".split())
         expected = parse_me_full_docstring("first", 2)
         self.assertEqual(actual, expected)
-
-    def test_function_delimiter_chars(self):
-        parser = FunctionParser()
-        with captured_output() as (out, _):
-            with self.assertRaises(SystemExit):
-                parser(
-                    different_delimiter_chars, "--help".split(), delimiter_chars="--"
-                )
-            help_message = out.getvalue()
-        self.assertIn("this one is a no brainer even with dashes", help_message)
-        self.assertIn(
-            "noticed you're missing docstring for two and I'm multiline too!",
-            help_message,
-        )
-
-    def test_function_description(self):
-        parser = FunctionParser()
-        parser(different_delimiter_chars, "1 2 3".split(), delimiter_chars="--")
-        self.assertEqual(
-            "I am a sneaky function.", different_delimiter_chars.parser.description
-        )
 
 
 class TestMethodParser(unittest.TestCase):

--- a/test/parsing_test.py
+++ b/test/parsing_test.py
@@ -63,7 +63,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": int, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", _NO_DEFAULT)],
-            ":",
+            "auto",
         )
         namespace = parser.parse_args("1 2 3".split())
         self.assertEqual(namespace.one, 1)
@@ -75,7 +75,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
-            ":",
+            "auto",
         )
         namespace = parser.parse_args("yes 42".split())
         self.assertEqual(namespace.one, "yes")
@@ -87,7 +87,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
-            ":",
+            "auto",
         )
         namespace = parser.parse_args("no 12 --three=23".split())
         self.assertEqual(namespace.one, "no")
@@ -99,7 +99,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
-            ":",
+            "auto",
         )
         with captured_output():
             self.assertRaises(
@@ -111,7 +111,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
-            ":",
+            "auto",
         )
         with captured_output():
             self.assertRaises(
@@ -142,7 +142,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
-            ":",
+            "auto",
         )
         args = _get_args_name_from_parser(parser)
         self.assertEqual(args, ["one", "two", "three"])
@@ -152,7 +152,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
-            ":",
+            "auto",
         )
         args = _get_args_name_from_parser(parser)
         self.assertNotIn("help", args)
@@ -162,7 +162,7 @@ class TestParsing(unittest.TestCase):
             parse_me_full_docstring,
             {"one": str, "two": int, "three": int},
             [("one", _NO_DEFAULT), ("two", _NO_DEFAULT), ("three", 12)],
-            ":",
+            "auto",
             log_level=True,
         )
         args = _get_args_name_from_parser(parser)
@@ -190,7 +190,7 @@ class TestParsing(unittest.TestCase):
             has_enum_argument,
             {"color": Color},
             [("color", _NO_DEFAULT)],
-            ":",
+            "auto",
         )
         # Find the action for 'color' and check its choices contain all members
         color_action = next(


### PR DESCRIPTION
## Summary

Cherry-picks the docstring-formats work (PR #53) directly onto `main`, without the `varargs-kwargs-handling` commits it was originally stacked on.

- Replaces the homemade docstring regex parser with `docstring-parser` (new runtime dependency)
- Supports Google, NumPy, reST/Sphinx, and Epytext styles with auto-detection
- Adds `docstring_style=` kwarg to `parse_this()`, `@create_parser`, and `@parse_class`
- **Breaking change**: removes `delimiter_chars=` parameter entirely
- README updated to show Google style example and link to other style guides

## Test plan

- [x] `pytest` — 145/145 passing
- [x] Coverage — 100%
- [x] `pre-commit run --all-files` — ruff, ruff-format, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)