### PR TITLE
release: v5.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "parse_this"
-version = "4.0.8"
+version = "5.0.1"
 description = "Makes it easy to create a command line interface for any function, method or classmethod."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `version` in `pyproject.toml` from `4.0.8` to `5.0.1`
- v5.0.0 was released prematurely (before the docstring-formats code landed on main); this release includes the actual breaking changes

Merging will trigger the publish workflow to tag and upload to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)