### PR TITLE
Replace mypy with ty for static type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,7 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+  - repo: https://github.com/astral-sh/ty
+    rev: 0.0.31
     hooks:
-      - id: mypy
-        additional_dependencies: [tokenize-rt==6.1.0]
+      - id: ty

--- a/parse_this/_protocols.py
+++ b/parse_this/_protocols.py
@@ -1,0 +1,17 @@
+from argparse import ArgumentParser
+from typing import Any, Protocol
+
+
+class _Named(Protocol):
+    """Any callable that carries standard function metadata."""
+
+    __name__: str
+    __doc__: str | None
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class _ParsedCallable(_Named, Protocol):
+    """A callable that has been decorated by @create_parser (has .parser)."""
+
+    parser: ArgumentParser

--- a/parse_this/args.py
+++ b/parse_this/args.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from itertools import zip_longest
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 _NO_DEFAULT = object()
 
@@ -26,7 +26,7 @@ def _get_args_and_defaults(args: List[str], defaults: Optional[Tuple[Any, ...]] 
     return args_and_defaults[::-1]
 
 
-def _get_args_to_parse(args: List[str], cli_arguments: Optional[List[str]] = None):
+def _get_args_to_parse(args: Optional[Sequence[str]], cli_arguments: Optional[Sequence[str]] = None):
     """Return the given arguments if it is not None else sys.argv if it contains
         something, an empty list otherwise.
 

--- a/parse_this/call.py
+++ b/parse_this/call.py
@@ -20,8 +20,8 @@ def _get_parser_call_method(func: Callable) -> Callable:
         ParseThisException if the decorated method is __init__, __init__ can
         only be decorated in a class decorated by parse_class
     """
-    func_name = func.__name__
-    parser = func.parser  # type: ignore[attr-defined]
+    func_name = func.__name__  # ty: ignore[unresolved-attribute]
+    parser = func.parser  # ty: ignore[unresolved-attribute]
 
     @wraps(func)
     def inner_call(instance: Any = None, args: Optional[List[str]] = None) -> Any:

--- a/parse_this/call.py
+++ b/parse_this/call.py
@@ -3,6 +3,7 @@ from argparse import Namespace
 from functools import wraps
 from typing import Any, Callable, List, Optional
 
+from parse_this._protocols import _ParsedCallable
 from parse_this.args import _get_args_to_parse
 from parse_this.exception import ParseThisException
 from parse_this.helpers import _get_args_name_from_parser
@@ -10,7 +11,7 @@ from parse_this.helpers import _get_args_name_from_parser
 _LOG = logging.getLogger(__name__)
 
 
-def _get_parser_call_method(func: Callable) -> Callable:
+def _get_parser_call_method(func: _ParsedCallable) -> Callable:
     """Returns the method that is linked to the 'call' method of the parser
 
     Args:
@@ -20,8 +21,8 @@ def _get_parser_call_method(func: Callable) -> Callable:
         ParseThisException if the decorated method is __init__, __init__ can
         only be decorated in a class decorated by parse_class
     """
-    func_name = func.__name__  # ty: ignore[unresolved-attribute]
-    parser = func.parser  # ty: ignore[unresolved-attribute]
+    func_name = func.__name__
+    parser = func.parser
 
     @wraps(func)
     def inner_call(instance: Any = None, args: Optional[List[str]] = None) -> Any:

--- a/parse_this/help/description.py
+++ b/parse_this/help/description.py
@@ -39,7 +39,7 @@ def _get_default_help_message(
         a tuple (arg_parse_description, complete_args_help)
     """
     if description is None:
-        description = "Argument parsing for %s" % func.__name__
+        description = "Argument parsing for %s" % func.__name__  # ty: ignore[unresolved-attribute]
     args_help = args_help or {}
     # If an argument is missing a help message we create a simple one
     for argument in [arg_name for arg_name in args if arg_name not in args_help]:
@@ -75,7 +75,7 @@ def prepare_doc(
         a dict indexed on the callable argument name and their associated help
         message
     """
-    _LOG.debug("Preparing doc for '%s'", func.__name__)
+    _LOG.debug("Preparing doc for '%s'", func.__name__)  # ty: ignore[unresolved-attribute]
     if not func.__doc__:
         return _get_default_help_message(func, args)
     try:

--- a/parse_this/help/description.py
+++ b/parse_this/help/description.py
@@ -1,8 +1,9 @@
 import logging
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from docstring_parser import DocstringStyle, ParseError, parse
 
+from parse_this._protocols import _Named
 from parse_this.exception import ParseThisException
 
 _LOG = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ _STYLE_MAP: Dict[str, DocstringStyle] = {
 
 
 def _get_default_help_message(
-    func: Callable,
+    func: _Named,
     args: List[str],
     description: Optional[str] = None,
     args_help: Optional[Dict[str, str]] = None,
@@ -39,7 +40,7 @@ def _get_default_help_message(
         a tuple (arg_parse_description, complete_args_help)
     """
     if description is None:
-        description = "Argument parsing for %s" % func.__name__  # ty: ignore[unresolved-attribute]
+        description = "Argument parsing for %s" % func.__name__
     args_help = args_help or {}
     # If an argument is missing a help message we create a simple one
     for argument in [arg_name for arg_name in args if arg_name not in args_help]:
@@ -58,7 +59,7 @@ def _collapse_whitespace(text: str) -> str:
 
 
 def prepare_doc(
-    func: Callable, args: List[str], style: str = "auto"
+    func: _Named, args: List[str], style: str = "auto"
 ) -> Tuple[str, Dict[str, str]]:
     """From the function docstring get the arg parse description and arguments
         help message. If there is no docstring simple description and help
@@ -75,7 +76,7 @@ def prepare_doc(
         a dict indexed on the callable argument name and their associated help
         message
     """
-    _LOG.debug("Preparing doc for '%s'", func.__name__)  # ty: ignore[unresolved-attribute]
+    _LOG.debug("Preparing doc for '%s'", func.__name__)
     if not func.__doc__:
         return _get_default_help_message(func, args)
     try:

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -55,7 +55,7 @@ class FunctionParser(object):
     def __call__(
         self,
         func: Callable,
-        args: typing.List[str] = None,
+        args: typing.Optional[typing.Sequence[str]] = None,
         docstring_style: str = "auto",
         log_level: bool = False,
         version: Optional[str] = None,
@@ -75,12 +75,12 @@ class FunctionParser(object):
             version: optional version string to enable a '--version' flag.
             When provided, '--version' prints this string and exits.
         """
-        _LOG.debug("Creating parser for %s", func.__name__)
+        _LOG.debug("Creating parser for %s", func.__name__)  # ty: ignore[unresolved-attribute]
         # Follow __wrapped__ so @create_parser can be stacked below decorators
         # that use functools.wraps around a *args/**kwargs wrapper.
         wrapped = unwrap(func)
         func_args, _, _, defaults, _, _, annotations = getfullargspec(wrapped)
-        func_args = _check_types(func.__name__, annotations, func_args, defaults)
+        func_args = _check_types(func.__name__, annotations, func_args, defaults)  # ty: ignore[unresolved-attribute]
         args_and_defaults = _get_args_and_defaults(func_args, defaults)
         parser = _get_arg_parser(
             func, annotations, args_and_defaults, docstring_style, log_level
@@ -111,7 +111,7 @@ class MethodParser(object):
     def __init__(
         self,
         docstring_style: str = "auto",
-        name: str = None,
+        name: Optional[str] = None,
         log_level: bool = False,
     ):
         """
@@ -138,7 +138,7 @@ class MethodParser(object):
         if not hasattr(func, "parser"):
             _LOG.debug(
                 "Creating parser for '%s'%s",
-                func.__name__,
+                func.__name__,  # ty: ignore[unresolved-attribute]
                 "/%s" % self._name if self._name else "",
             )
             # Follow __wrapped__ so @create_parser can be stacked below
@@ -146,7 +146,7 @@ class MethodParser(object):
             # wrapper.
             wrapped = unwrap(func)
             func_args, _, _, defaults, _, _, annotations = getfullargspec(wrapped)
-            func_args = _check_types(func.__name__, annotations, func_args, defaults)
+            func_args = _check_types(func.__name__, annotations, func_args, defaults)  # ty: ignore[unresolved-attribute]
             args_and_defaults = _get_args_and_defaults(func_args, defaults)
             parser = _get_arg_parser(
                 func,
@@ -155,7 +155,7 @@ class MethodParser(object):
                 self._docstring_style,
                 self._log_level,
             )
-            parser.get_name = lambda: self._name or func.__name__  # type: ignore[attr-defined]
+            parser.get_name = lambda: self._name or func.__name__  # ty: ignore[unresolved-attribute]
             self._set_method_parser(func, parser)
 
         @wraps(func)
@@ -176,13 +176,13 @@ class ClassParser(object):
 
     _parse_private: bool
     _description: Optional[str]
-    _cls: Type = None
+    _cls: Optional[Type] = None
     _log_level: bool
     _version: Optional[str]
 
     def __init__(
         self,
-        description: str = None,
+        description: Optional[str] = None,
         parse_private: bool = False,
         log_level: bool = False,
         version: Optional[str] = None,
@@ -247,7 +247,7 @@ class ClassParser(object):
         for method_name, parser in methods_to_parse.items():
             # We use the name provided in 'create_parser` or the name of the
             # decorated method
-            parser_name = parser.get_name()  # type: ignore[attr-defined]
+            parser_name = parser.get_name()  # ty: ignore[unresolved-attribute]
             # Make the method name compatible for the argument parsing
             if parser_name.startswith("_"):
                 if not self._parse_private:
@@ -269,7 +269,7 @@ class ClassParser(object):
 
     def _set_class_parser(
         self,
-        init_parser: ArgumentParser,
+        init_parser: Optional[ArgumentParser],
         methods_to_parse: Dict[str, ArgumentParser],
         cls: Type,
     ):
@@ -312,7 +312,7 @@ class ClassParser(object):
         if init_parser:
             parser_to_method["__init__"] = "__init__"
         self._set_parser_call_method(parser_to_method, top_level_parser)
-        cls.parser = top_level_parser
+        cls.parser = top_level_parser  # ty: ignore[unresolved-attribute]
 
     @typing.no_type_check  # dynamically attaches .parser and .call to objects
     def _set_parser_call_method(
@@ -320,7 +320,7 @@ class ClassParser(object):
     ):
         top_level_parser.call = self._get_parser_call_method(parser_to_method)
 
-    def _get_parser_call_method(self, parser_to_method: Dict[str, Callable]):
+    def _get_parser_call_method(self, parser_to_method: Dict[str, str]):
         """Return the parser special method 'call' that handles sub-command
             calling.
 
@@ -339,7 +339,7 @@ class ClassParser(object):
                     the default, and __init__ is decorated the object will be
                     instantiated on the fly from the command line arguments
             """
-            parser = self._cls.parser
+            parser = self._cls.parser  # ty: ignore[unresolved-attribute]
             namespace = parser.parse_args(_get_args_to_parse(args))
             method_name = parser_to_method[namespace.method]
             if instance is None:
@@ -358,7 +358,7 @@ class ClassParser(object):
                     raise ParseThisException(
                         f"'__init__' method is not decorated. "
                         f"Please provide an instance to "
-                        f"'{self._cls.__name__}.parser.call', decorate the "
+                        f"'{self._cls.__name__}.parser.call', decorate the "  # ty: ignore[unresolved-attribute]
                         f"'__init__' method with 'create_parser', or expose "
                         f"only 'classmethod'/'staticmethod' subcommands so "
                         f"no instance is required."

--- a/parse_this/parsers.py
+++ b/parse_this/parsers.py
@@ -5,6 +5,8 @@ from functools import wraps
 from inspect import getfullargspec, unwrap
 from typing import Callable, Dict, Optional, Type
 
+from parse_this._protocols import _Named
+
 from parse_this.args import _get_args_and_defaults, _get_args_to_parse
 from parse_this.call import _call, _call_method_from_namespace, _get_parser_call_method
 from parse_this.exception import ParseThisException
@@ -54,7 +56,7 @@ class FunctionParser(object):
 
     def __call__(
         self,
-        func: Callable,
+        func: _Named,
         args: typing.Optional[typing.Sequence[str]] = None,
         docstring_style: str = "auto",
         log_level: bool = False,
@@ -75,12 +77,12 @@ class FunctionParser(object):
             version: optional version string to enable a '--version' flag.
             When provided, '--version' prints this string and exits.
         """
-        _LOG.debug("Creating parser for %s", func.__name__)  # ty: ignore[unresolved-attribute]
+        _LOG.debug("Creating parser for %s", func.__name__)
         # Follow __wrapped__ so @create_parser can be stacked below decorators
         # that use functools.wraps around a *args/**kwargs wrapper.
         wrapped = unwrap(func)
         func_args, _, _, defaults, _, _, annotations = getfullargspec(wrapped)
-        func_args = _check_types(func.__name__, annotations, func_args, defaults)  # ty: ignore[unresolved-attribute]
+        func_args = _check_types(func.__name__, annotations, func_args, defaults)
         args_and_defaults = _get_args_and_defaults(func_args, defaults)
         parser = _get_arg_parser(
             func, annotations, args_and_defaults, docstring_style, log_level
@@ -129,7 +131,7 @@ class MethodParser(object):
         self._name = name
         self._log_level = log_level
 
-    def __call__(self, func: Callable):
+    def __call__(self, func: _Named):
         """Add an argument parser attribute `parser` to the decorated function.
 
         Args:
@@ -138,7 +140,7 @@ class MethodParser(object):
         if not hasattr(func, "parser"):
             _LOG.debug(
                 "Creating parser for '%s'%s",
-                func.__name__,  # ty: ignore[unresolved-attribute]
+                func.__name__,
                 "/%s" % self._name if self._name else "",
             )
             # Follow __wrapped__ so @create_parser can be stacked below
@@ -146,7 +148,7 @@ class MethodParser(object):
             # wrapper.
             wrapped = unwrap(func)
             func_args, _, _, defaults, _, _, annotations = getfullargspec(wrapped)
-            func_args = _check_types(func.__name__, annotations, func_args, defaults)  # ty: ignore[unresolved-attribute]
+            func_args = _check_types(func.__name__, annotations, func_args, defaults)
             args_and_defaults = _get_args_and_defaults(func_args, defaults)
             parser = _get_arg_parser(
                 func,

--- a/parse_this/parsing.py
+++ b/parse_this/parsing.py
@@ -80,7 +80,7 @@ def _get_arg_parser(
         log_level: indicate whether or not a '--log-level' argument should be
         handled to set the log level during the execution
     """
-    _LOG.debug("Creating ArgumentParser for '%s'", func.__name__)
+    _LOG.debug("Creating ArgumentParser for '%s'", func.__name__)  # ty: ignore[unresolved-attribute]
     description, arg_help = prepare_doc(
         func, [x for (x, _) in args_and_defaults], docstring_style
     )
@@ -137,7 +137,7 @@ def _add_required_argument(
     """
     arg_type = _unwrap_optional(arg_type)
     if arg_type is bool:
-        _LOG.debug("Adding optional flag %s.%s (default: True)", func.__name__, arg)
+        _LOG.debug("Adding optional flag %s.%s (default: True)", func.__name__, arg)  # ty: ignore[unresolved-attribute]
         parser.add_argument(
             "--%s" % arg,
             default=True,
@@ -147,11 +147,11 @@ def _add_required_argument(
         )
     elif _is_literal_type(arg_type):
         values = _get_literal_values(arg_type)
-        _validate_literal_values(func.__name__, arg, values)
+        _validate_literal_values(func.__name__, arg, values)  # ty: ignore[unresolved-attribute]
         literal_type = type(values[0])
         _LOG.debug(
             "Adding positional literal argument %s.%s: %s",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             values,
         )
@@ -159,7 +159,7 @@ def _add_required_argument(
     elif _is_enum_type(arg_type):
         _LOG.debug(
             "Adding positional enum argument %s.%s: %s",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             arg_type,
         )
@@ -175,14 +175,14 @@ def _add_required_argument(
     elif _is_sequence_type(arg_type):
         _LOG.debug(
             "Adding positional sequence argument %s.%s: %s",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             arg_type,
         )
         element_type = _get_element_type(arg_type)
         parser.add_argument(arg, help=help_msg, type=element_type, nargs="+")
     else:
-        _LOG.debug("Adding positional argument %s.%s: %s", func.__name__, arg, arg_type)
+        _LOG.debug("Adding positional argument %s.%s: %s", func.__name__, arg, arg_type)  # ty: ignore[unresolved-attribute]
         parser.add_argument(arg, help=help_msg, type=arg_type)
 
 
@@ -207,22 +207,22 @@ def _add_optional_argument(
     arg_type = _unwrap_optional(arg_type)
     if default is None and arg_type is None:
         raise ParseThisException(
-            f"parameter '{arg}' of '{func.__name__}' has default None but no "
+            f"parameter '{arg}' of '{func.__name__}' has default None but no "  # ty: ignore[unresolved-attribute]
             f"type annotation. Add an annotation, for example: "
             f"{arg}: int | None = None"
         )
     if _is_literal_type(arg_type):
         values = _get_literal_values(arg_type)
-        _validate_literal_values(func.__name__, arg, values)
+        _validate_literal_values(func.__name__, arg, values)  # ty: ignore[unresolved-attribute]
         literal_type = type(values[0])
         if default is not None and default not in values:
             raise ParseThisException(
-                f"Default value {default!r} for '{arg}' in '{func.__name__}' "
+                f"Default value {default!r} for '{arg}' in '{func.__name__}' "  # ty: ignore[unresolved-attribute]
                 f"is not one of the allowed Literal values: {values}"
             )
         _LOG.debug(
             "Adding optional literal argument %s.%s: %s (default: %s)",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             values,
             default,
@@ -240,7 +240,7 @@ def _add_optional_argument(
         action = "store_false" if default else "store_true"
         _LOG.debug(
             "Adding optional flag %s.%s (default: %s)",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             default,
         )
@@ -248,7 +248,7 @@ def _add_optional_argument(
     elif _is_enum_type(arg_type):
         _LOG.debug(
             "Adding optional enum argument %s.%s: %s (default: %s)",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             arg_type,
             default,
@@ -266,7 +266,7 @@ def _add_optional_argument(
     elif _is_sequence_type(arg_type):
         _LOG.debug(
             "Adding optional sequence argument %s.%s: %s (default: %s)",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             arg_type,
             default,
@@ -278,7 +278,7 @@ def _add_optional_argument(
     else:
         _LOG.debug(
             "Adding optional argument %s.%s: %s (default: %s)",
-            func.__name__,
+            func.__name__,  # ty: ignore[unresolved-attribute]
             arg,
             arg_type,
             default,

--- a/parse_this/parsing.py
+++ b/parse_this/parsing.py
@@ -3,6 +3,7 @@ import logging
 from argparse import ArgumentParser
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
 
+from parse_this._protocols import _Named
 from parse_this.args import _NO_DEFAULT
 from parse_this.exception import ParseThisException
 from parse_this.help.description import prepare_doc
@@ -62,7 +63,7 @@ def _get_parseable_methods(
 
 
 def _get_arg_parser(
-    func: Callable,
+    func: _Named,
     annotations: Dict[str, Callable],
     args_and_defaults: List[Tuple[str, Any]],
     docstring_style: str,
@@ -80,7 +81,7 @@ def _get_arg_parser(
         log_level: indicate whether or not a '--log-level' argument should be
         handled to set the log level during the execution
     """
-    _LOG.debug("Creating ArgumentParser for '%s'", func.__name__)  # ty: ignore[unresolved-attribute]
+    _LOG.debug("Creating ArgumentParser for '%s'", func.__name__)
     description, arg_help = prepare_doc(
         func, [x for (x, _) in args_and_defaults], docstring_style
     )
@@ -121,7 +122,7 @@ def _validate_literal_values(func_name: str, arg: str, values: tuple) -> None:
 
 def _add_required_argument(
     parser: ArgumentParser,
-    func: Callable,
+    func: _Named,
     arg: str,
     arg_type: Any,
     help_msg: str,
@@ -137,7 +138,7 @@ def _add_required_argument(
     """
     arg_type = _unwrap_optional(arg_type)
     if arg_type is bool:
-        _LOG.debug("Adding optional flag %s.%s (default: True)", func.__name__, arg)  # ty: ignore[unresolved-attribute]
+        _LOG.debug("Adding optional flag %s.%s (default: True)", func.__name__, arg)
         parser.add_argument(
             "--%s" % arg,
             default=True,
@@ -147,11 +148,11 @@ def _add_required_argument(
         )
     elif _is_literal_type(arg_type):
         values = _get_literal_values(arg_type)
-        _validate_literal_values(func.__name__, arg, values)  # ty: ignore[unresolved-attribute]
+        _validate_literal_values(func.__name__, arg, values)
         literal_type = type(values[0])
         _LOG.debug(
             "Adding positional literal argument %s.%s: %s",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             values,
         )
@@ -159,7 +160,7 @@ def _add_required_argument(
     elif _is_enum_type(arg_type):
         _LOG.debug(
             "Adding positional enum argument %s.%s: %s",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             arg_type,
         )
@@ -175,20 +176,20 @@ def _add_required_argument(
     elif _is_sequence_type(arg_type):
         _LOG.debug(
             "Adding positional sequence argument %s.%s: %s",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             arg_type,
         )
         element_type = _get_element_type(arg_type)
         parser.add_argument(arg, help=help_msg, type=element_type, nargs="+")
     else:
-        _LOG.debug("Adding positional argument %s.%s: %s", func.__name__, arg, arg_type)  # ty: ignore[unresolved-attribute]
+        _LOG.debug("Adding positional argument %s.%s: %s", func.__name__, arg, arg_type)
         parser.add_argument(arg, help=help_msg, type=arg_type)
 
 
 def _add_optional_argument(
     parser: ArgumentParser,
-    func: Callable,
+    func: _Named,
     arg: str,
     arg_type: Any,
     default: Any,
@@ -207,22 +208,22 @@ def _add_optional_argument(
     arg_type = _unwrap_optional(arg_type)
     if default is None and arg_type is None:
         raise ParseThisException(
-            f"parameter '{arg}' of '{func.__name__}' has default None but no "  # ty: ignore[unresolved-attribute]
+            f"parameter '{arg}' of '{func.__name__}' has default None but no "
             f"type annotation. Add an annotation, for example: "
             f"{arg}: int | None = None"
         )
     if _is_literal_type(arg_type):
         values = _get_literal_values(arg_type)
-        _validate_literal_values(func.__name__, arg, values)  # ty: ignore[unresolved-attribute]
+        _validate_literal_values(func.__name__, arg, values)
         literal_type = type(values[0])
         if default is not None and default not in values:
             raise ParseThisException(
-                f"Default value {default!r} for '{arg}' in '{func.__name__}' "  # ty: ignore[unresolved-attribute]
+                f"Default value {default!r} for '{arg}' in '{func.__name__}' "
                 f"is not one of the allowed Literal values: {values}"
             )
         _LOG.debug(
             "Adding optional literal argument %s.%s: %s (default: %s)",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             values,
             default,
@@ -240,7 +241,7 @@ def _add_optional_argument(
         action = "store_false" if default else "store_true"
         _LOG.debug(
             "Adding optional flag %s.%s (default: %s)",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             default,
         )
@@ -248,7 +249,7 @@ def _add_optional_argument(
     elif _is_enum_type(arg_type):
         _LOG.debug(
             "Adding optional enum argument %s.%s: %s (default: %s)",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             arg_type,
             default,
@@ -266,7 +267,7 @@ def _add_optional_argument(
     elif _is_sequence_type(arg_type):
         _LOG.debug(
             "Adding optional sequence argument %s.%s: %s (default: %s)",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             arg_type,
             default,
@@ -278,7 +279,7 @@ def _add_optional_argument(
     else:
         _LOG.debug(
             "Adding optional argument %s.%s: %s (default: %s)",
-            func.__name__,  # ty: ignore[unresolved-attribute]
+            func.__name__,
             arg,
             arg_type,
             default,

--- a/parse_this/type_check.py
+++ b/parse_this/type_check.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from parse_this.exception import ParseThisException
 
@@ -7,7 +7,7 @@ def _check_types(
     func_name: str,
     annotations: Dict[str, Callable],
     func_args: List[str],
-    defaults: Tuple,
+    defaults: Optional[Tuple],
 ):
     """Make sure that enough types were given to ensure conversion. Also remove
        potential 'self'/'cls' from the function arguments.

--- a/plans/validated-hatching-kay.md
+++ b/plans/validated-hatching-kay.md
@@ -1,0 +1,100 @@
+# Plan: Move Type Checking from mypy to ty
+
+## Context
+
+The project currently uses mypy for static type checking, integrated via pre-commit. Ty is a new Rust-based type checker from Astral (makers of ruff and uv), designed to be significantly faster. This migration swaps mypy for ty in both the pre-commit hooks and dev dependencies, and aligns the few type-ignore comments with ty's error code naming.
+
+## Files to Modify
+
+1. **`pyproject.toml`** — remove `[tool.mypy]` section, replace `mypy` with `ty` in dev deps
+2. **`.pre-commit-config.yaml`** — replace the mypy hook with ty's hook
+3. **`parse_this/call.py`** — update `# type: ignore[attr-defined]` → `# type: ignore[attribute-access]`
+4. **`parse_this/parsers.py`** — update the two `# type: ignore[attr-defined]` occurrences
+
+## Changes
+
+### 1. `pyproject.toml`
+
+Remove the `[tool.mypy]` section entirely:
+```toml
+# DELETE:
+[tool.mypy]
+no_strict_optional = true
+show_error_codes = true
+```
+
+Replace `mypy` with `ty` in dev dependencies:
+```toml
+[project.optional-dependencies]
+dev = [
+    "ipython",
+    "ty",          # was: mypy
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+    "ruff",
+]
+```
+
+No `[tool.ty]` section is needed: ty has no equivalent of `no_strict_optional`
+(it's always strict about None), and the codebase already uses explicit
+`Optional[...]` everywhere, so no config is required.
+
+### 2. `.pre-commit-config.yaml`
+
+Replace the mirrors-mypy repo block with ty's pre-commit hook:
+```yaml
+# DELETE:
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        additional_dependencies: [tokenize-rt==6.1.0]
+
+# ADD:
+  - repo: https://github.com/astral-sh/ty
+    rev: 0.0.0-alpha.6
+    hooks:
+      - id: ty
+```
+
+> **Note**: verify the latest ty release tag before committing by checking
+> https://github.com/astral-sh/ty/releases.
+
+### 3. `parse_this/call.py` line 24
+
+```python
+# Before:
+parser = func.parser  # type: ignore[attr-defined]
+# After:
+parser = func.parser  # type: ignore[attribute-access]
+```
+
+### 4. `parse_this/parsers.py`
+
+Line 158:
+```python
+# Before:
+parser.get_name = lambda: self._name or func.__name__  # type: ignore[attr-defined]
+# After:
+parser.get_name = lambda: self._name or func.__name__  # type: ignore[attribute-access]
+```
+
+Line 250:
+```python
+# Before:
+parser_name = parser.get_name()  # type: ignore[attr-defined]
+# After:
+parser_name = parser.get_name()  # type: ignore[attribute-access]
+```
+
+> The `@typing.no_type_check` decorators in `parsers.py` require no changes —
+> ty respects this standard decorator.
+
+## Verification
+
+1. Run `ty check` to confirm no errors on the codebase
+2. Run `pre-commit run --all-files` to verify the hook works end-to-end
+3. Run `pytest` to confirm tests still pass with no regressions
+4. Commit changes (pyproject.toml + .pre-commit-config.yaml changes in one commit;
+   source code ignore-comment updates in another, or all together)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "ipython",
-    "mypy",
+    "ty",
     "pre-commit",
     "pytest",
     "pytest-cov",
@@ -48,10 +48,6 @@ include = ["parse_this*"]
 
 [tool.setuptools.package-data]
 parse_this = ["py.typed"]
-
-[tool.mypy]
-no_strict_optional = true
-show_error_codes = true
 
 [tool.pytest.ini_options]
 cache_dir = ".pytest_cache"

--- a/test/call_test.py
+++ b/test/call_test.py
@@ -1,5 +1,5 @@
 import unittest
-from collections import namedtuple
+from argparse import Namespace
 
 from parse_this.call import (
     _call,
@@ -33,22 +33,19 @@ class TestCall(unittest.TestCase):
         self.assertEqual(call_method(args="yes 2".split()), "yesyes")
 
     def test_call_on_parse_me_no_docstring(self):
-        Namespace = namedtuple("Namespace", ["one", "two", "three"])
-        fake_namespace = Namespace(**{"one": 2, "two": 12, "three": 3})
+        fake_namespace = Namespace(one=2, two=12, three=3)
         self.assertEqual(
             _call(parse_me_no_docstring, ["one", "two", "three"], fake_namespace),
             (24, 9),
         )
 
     def test_call_method_from_namespace_create_instance(self):
-        Namespace = namedtuple("Namespace", ["a"])
         fake_namespace = Namespace(a=2)
         parseable = _call_method_from_namespace(Parseable, "__init__", fake_namespace)
         self.assertIsInstance(parseable, Parseable)
         self.assertEqual(parseable._a, 2)
 
     def test_call_method_from_namespace_execution(self):
-        Namespace = namedtuple("Namespace", ["d"])
         fake_namespace = Namespace(d=2)
         self.assertEqual(
             _call_method_from_namespace(Parseable(12), "parseable", fake_namespace), 24
@@ -56,7 +53,7 @@ class TestCall(unittest.TestCase):
 
     def test_get_parser_call_method_preserves_name(self):
         call_method = _get_parser_call_method(concatenate_string)
-        self.assertEqual(call_method.__name__, "concatenate_string")
+        self.assertEqual(call_method.__name__, "concatenate_string")  # ty: ignore[unresolved-attribute]
 
     def test_get_parser_call_method_preserves_doc(self):
         call_method = _get_parser_call_method(i_am_parseable)
@@ -64,7 +61,7 @@ class TestCall(unittest.TestCase):
 
     def test_get_parser_call_method_preserves_wrapped(self):
         call_method = _get_parser_call_method(concatenate_string)
-        self.assertIs(call_method.__wrapped__, concatenate_string)
+        self.assertIs(call_method.__wrapped__, concatenate_string)  # ty: ignore[unresolved-attribute]
 
 
 if __name__ == "__main__":

--- a/test/docstring_styles_test.py
+++ b/test/docstring_styles_test.py
@@ -219,8 +219,8 @@ class TestDocstringStyleKwargFlow(unittest.TestCase):
         self.assertEqual(add_actions["n"].help, "value to add")
         self.assertEqual(mul_actions["n"].help, "value to multiply")
         # End-to-end dispatch using the top-level class parser.
-        self.assertEqual(Mixed.parser.call("10 add 5".split()), 15)
-        self.assertEqual(Mixed.parser.call("10 mul 5".split()), 50)
+        self.assertEqual(Mixed.parser.call("10 add 5".split()), 15)  # ty:ignore[unresolved-attribute]
+        self.assertEqual(Mixed.parser.call("10 mul 5".split()), 50)  # ty:ignore[unresolved-attribute]
 
 
 if __name__ == "__main__":

--- a/test/help_test.py
+++ b/test/help_test.py
@@ -74,7 +74,7 @@ class TestHelp(unittest.TestCase):
 class TestFullHelpAction(unittest.TestCase):
     def test_help_is_complete(self):
         with captured_output() as (out, _):
-            self.assertRaises(SystemExit, Parseable.parser.parse_args, ["-h"])
+            self.assertRaises(SystemExit, Parseable.parser.parse_args, ["-h"])  # ty:ignore[unresolved-attribute]
             help_message = out.getvalue()
         self.assertIn("parseable", help_message)
         # Private methods are hidden by default
@@ -85,7 +85,7 @@ class TestFullHelpAction(unittest.TestCase):
     def test_help_is_complete_with_private_method(self):
         with captured_output() as (out, _):
             self.assertRaises(
-                SystemExit, ParseableWithPrivateMethod.parser.parse_args, ["-h"]
+                SystemExit, ParseableWithPrivateMethod.parser.parse_args, ["-h"]  # ty:ignore[unresolved-attribute]
             )
             help_message = out.getvalue()
         self.assertIn("parseable", help_message)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,4 +1,5 @@
 import enum
+from typing import Optional
 
 from parse_this import create_parser, parse_class
 
@@ -88,7 +89,7 @@ class ParseableWithLogLevel(object):
 
 
 @create_parser()
-def has_none_default_value(a: int, b: str = None):
+def has_none_default_value(a: int, b: Optional[str] = None):
     return a, b
 
 
@@ -278,7 +279,7 @@ def has_list_argument(values: list[int]):
 
 
 @create_parser()
-def has_optional_list_argument(name: str, tags: list[str] = None):
+def has_optional_list_argument(name: str, tags: Optional[list[str]] = None):
     """Tag something.
 
     Args:
@@ -299,7 +300,7 @@ def has_tuple_argument(coords: tuple[float, ...]):
 
 
 @create_parser()
-def has_optional_tuple_argument(label: str, dims: tuple[int, ...] = None):
+def has_optional_tuple_argument(label: str, dims: Optional[tuple[int, ...]] = None):
     """Label dimensions.
 
     Args:
@@ -310,7 +311,7 @@ def has_optional_tuple_argument(label: str, dims: tuple[int, ...] = None):
 
 
 @create_parser()
-def has_tuple_argument_without_type(coords: tuple = None):
+def has_tuple_argument_without_type(coords: Optional[tuple] = None):
     """Process coordinates.
 
     Args:

--- a/test/literal_test.py
+++ b/test/literal_test.py
@@ -129,5 +129,5 @@ class TestLiteralErrors(unittest.TestCase):
         with self.assertRaises(ParseThisException):
 
             @create_parser()
-            def bad_default(val: Literal["a", "b"] = "c"):  # type: ignore[assignment]
+            def bad_default(val: Literal["a", "b"] = "c"):  # ty: ignore[invalid-parameter-default]
                 return val

--- a/test/parsers_test.py
+++ b/test/parsers_test.py
@@ -70,9 +70,9 @@ class TestMethodParser(unittest.TestCase):
 
 class TestClassParser(unittest.TestCase):
     def test_parse_class_description(self):
-        self.assertEqual(NeedParsing.parser.description, "Hello World")
+        self.assertEqual(NeedParsing.parser.description, "Hello World")  # ty:ignore[unresolved-attribute]
         self.assertEqual(
-            ShowMyDocstring.parser.description, "This should be the parser description"
+            ShowMyDocstring.parser.description, "This should be the parser description"  # ty:ignore[unresolved-attribute]
         )
 
     def test_parse_class_add_parser(self):
@@ -81,26 +81,26 @@ class TestClassParser(unittest.TestCase):
         self.assertTrue(hasattr(ShowMyDocstring, "parser"))
 
     def test_parse_class_subparsers(self):
-        parser = NeedParsing.parser
+        parser = NeedParsing.parser  # ty:ignore[unresolved-attribute]
         self.assertEqual(parser.call("12 multiply-self-arg 2".split()), 24)
         self.assertEqual(
             parser.call("12 could-you-parse-me yes 2 --three 4".split()), ("yesyes", 16)
         )
 
     def test_parse_class_expose_private_method(self):
-        parser = NeedParsing.parser
+        parser = NeedParsing.parser  # ty:ignore[unresolved-attribute]
         self.assertEqual(parser.call("12 private-method 2".split()), 24)
 
     def test_parse_class_expose_special_method(self):
-        parser = NeedParsing.parser
+        parser = NeedParsing.parser  # ty:ignore[unresolved-attribute]
         self.assertEqual(parser.call("12 str".split()), "12")
 
     def test_parse_class_do_not_expose_private_methods(self):
         with captured_output():
             with self.assertRaises(SystemExit):
-                ShowMyDocstring.parser.parse_args("will-not-appear 12".split())
+                ShowMyDocstring.parser.parse_args("will-not-appear 12".split())  # ty:ignore[unresolved-attribute]
             with self.assertRaises(SystemExit):
-                ShowMyDocstring.parser.parse_args("str".split())
+                ShowMyDocstring.parser.parse_args("str".split())  # ty:ignore[unresolved-attribute]
 
     def test_parse_class_method_is_still_parseable(self):
         need_parsing = NeedParsing(12)
@@ -111,15 +111,15 @@ class TestClassParser(unittest.TestCase):
 
     def test_parse_class_init_need_decoration(self):
         with self.assertRaises(ParseThisException):
-            NeedInitDecorator.parser.call("do-stuff 12".split())
+            NeedInitDecorator.parser.call("do-stuff 12".split())  # ty:ignore[unresolved-attribute]
 
     def test_parse_class_need_init_decorator_with_instance(self):
         instance = NeedInitDecorator(2)
         self.assertEqual(
-            NeedInitDecorator.parser.call("do-stuff 12".split(), instance), 12
+            NeedInitDecorator.parser.call("do-stuff 12".split(), instance), 12  # ty:ignore[unresolved-attribute]
         )
         self.assertEqual(
-            NeedInitDecorator.parser.call("do-stuff 12 --div 3".split(), instance), 8
+            NeedInitDecorator.parser.call("do-stuff 12 --div 3".split(), instance), 8  # ty:ignore[unresolved-attribute]
         )
 
     def test_parse_class_classmethod_is_sub_command(self):
@@ -127,34 +127,34 @@ class TestClassParser(unittest.TestCase):
         # is exposed as a subcommand. The classmethod's cls is bound at
         # descriptor resolution time, not from the __init__'d instance, so
         # it runs exactly as if called through the class itself.
-        result = NeedParsing.parser.call("12 parse-me-if-you-can one 2".split())
+        result = NeedParsing.parser.call("12 parse-me-if-you-can one 2".split())  # ty:ignore[unresolved-attribute]
         self.assertEqual(result, ("oneone", 144))
 
     def test_parse_class_classmethod_with_cls_access(self):
         # The classmethod can access cls — verify we get the real class,
         # not a surrogate.
-        result = ClassAndStaticMethods.parser.call("5 cls-name-upper !".split())
+        result = ClassAndStaticMethods.parser.call("5 cls-name-upper !".split())  # ty:ignore[unresolved-attribute]
         self.assertEqual(result, "CLASSANDSTATICMETHODS!")
 
     def test_parse_class_staticmethod_is_sub_command(self):
-        result = ClassAndStaticMethods.parser.call("5 static-add 3 4".split())
+        result = ClassAndStaticMethods.parser.call("5 static-add 3 4".split())  # ty:ignore[unresolved-attribute]
         self.assertEqual(result, 7)
 
     def test_parse_class_instance_method_still_works(self):
         # Make sure that adding classmethod/staticmethod support didn't
         # break instance methods in the same class.
-        result = ClassAndStaticMethods.parser.call("5 times 6".split())
+        result = ClassAndStaticMethods.parser.call("5 times 6".split())  # ty:ignore[unresolved-attribute]
         self.assertEqual(result, 30)
 
     def test_parse_class_no_init_classmethod_dispatch(self):
         # A class with no decorated __init__ can still dispatch its
         # classmethods because classmethods don't need an instance — the
         # class object itself is used for dispatch.
-        result = OnlyClassMethods.parser.call("described hello".split())
+        result = OnlyClassMethods.parser.call("described hello".split())  # ty:ignore[unresolved-attribute]
         self.assertEqual(result, "hello: OnlyClassMethods")
 
     def test_parse_class_no_init_staticmethod_dispatch(self):
-        result = OnlyClassMethods.parser.call("square 9".split())
+        result = OnlyClassMethods.parser.call("square 9".split())  # ty:ignore[unresolved-attribute]
         self.assertEqual(result, 81)
 
     def test_subcommand_parse_error_shows_subcommand_usage_not_top_parser(self):
@@ -163,7 +163,7 @@ class TestClassParser(unittest.TestCase):
         the top-level parser's usage (which lists all available subcommands)."""
         with captured_output() as (_, err):
             with self.assertRaises(SystemExit):
-                SubCmdParseError.parser.call("1 sub-cmd 2 --unknown-flag".split())
+                SubCmdParseError.parser.call("1 sub-cmd 2 --unknown-flag".split())  # ty:ignore[unresolved-attribute]
             error_output = err.getvalue()
         # The subcommand name must appear in the error output as a plain word,
         # confirming the subcommand's usage line was printed.
@@ -176,7 +176,7 @@ class TestClassParser(unittest.TestCase):
     def test_parse_class_unrecognized_argument(self):
         with captured_output() as (_, err):
             with self.assertRaises(SystemExit):
-                ParseMyInitOnly.parser.call("--unknown-flag".split())
+                ParseMyInitOnly.parser.call("--unknown-flag".split())  # ty:ignore[unresolved-attribute]
             error_output = err.getvalue()
         self.assertIn("unrecognized arguments", error_output)
         self.assertIn("--unknown-flag", error_output)
@@ -260,7 +260,7 @@ class TestDecoratorStacking(unittest.TestCase):
                 """
                 return self._base + value
 
-        self.assertEqual(Calculator.parser.call("10 add 5".split()), 15)
+        self.assertEqual(Calculator.parser.call("10 add 5".split()), 15)  # ty:ignore[unresolved-attribute]
 
 
 class TestLogLevel(unittest.TestCase):
@@ -285,7 +285,7 @@ class TestLogLevel(unittest.TestCase):
 
     @patch("parse_this.call.logging.basicConfig")
     def test_parse_class_with_log_level(self, mock_basic_config):
-        result = ParseableWithLogLevel.parser.call(
+        result = ParseableWithLogLevel.parser.call(  # ty:ignore[unresolved-attribute]
             "12 --log-level ERROR parseable 2".split()
         )
         self.assertEqual(result, 24)

--- a/test/parsing_test.py
+++ b/test/parsing_test.py
@@ -42,7 +42,7 @@ class TestParsing(unittest.TestCase):
     def test_get_arg_parser_none_default_value_without_type(self):
         with self.assertRaises(ParseThisException):
 
-            @create_parser(int)
+            @create_parser(int)  # ty: ignore[invalid-argument-type]
             def have_none_default_value(a: int, b=None):
                 pass
 

--- a/test/version_test.py
+++ b/test/version_test.py
@@ -100,7 +100,7 @@ class TestClassParserVersion(unittest.TestCase):
     def test_version_flag_prints_and_exits(self):
         with captured_output() as (out, err):
             with self.assertRaises(SystemExit) as ctx:
-                VersionedApp.parser.call(args=["--version"])
+                VersionedApp.parser.call(args=["--version"])  # ty:ignore[unresolved-attribute]
         self.assertEqual(ctx.exception.code, 0)
         printed = out.getvalue() + err.getvalue()
         self.assertIn("myapp 2.0.1", printed)
@@ -108,13 +108,13 @@ class TestClassParserVersion(unittest.TestCase):
     def test_version_in_help(self):
         with captured_output() as (out, _):
             with self.assertRaises(SystemExit):
-                VersionedApp.parser.call(args=["--help"])
+                VersionedApp.parser.call(args=["--help"])  # ty:ignore[unresolved-attribute]
         self.assertIn("--version", out.getvalue())
 
     def test_no_version_flag_when_omitted(self):
         with captured_output():
             with self.assertRaises(SystemExit):
-                UnversionedApp.parser.call(args=["--version"])
+                UnversionedApp.parser.call(args=["--version"])  # ty:ignore[unresolved-attribute]
 
     def test_call_without_version_still_works(self):
-        self.assertEqual(VersionedApp.parser.call(args=["3", "run", "4"]), 12)
+        self.assertEqual(VersionedApp.parser.call(args=["3", "run", "4"]), 12)  # ty:ignore[unresolved-attribute]


### PR DESCRIPTION
## Summary

- Swap `mypy` pre-commit hook for `astral-sh/ty@0.0.31` (Rust-based, no extra dependencies)
- Replace `mypy` with `ty` in dev dependencies; remove `[tool.mypy]` config
- Fix annotation bugs that `no_strict_optional = true` was silently hiding:
  - Wrap `str`, `List[str]`, `Tuple`, and class attribute `Type` with `Optional` in `parsers.py`, `type_check.py`, `args.py`, and test fixtures
  - Widen `args` parameter from `List[str]` to `Sequence[str]` (covariant, accepts `list[LiteralString]` from `.split()` call sites)
  - Fix `Dict[str, Callable]` → `Dict[str, str]` in `_get_parser_call_method` (values are method name strings)
  - Fix `_set_class_parser` to accept `Optional[ArgumentParser]`
- Replace `# type: ignore[attr-defined]` with `# ty: ignore[unresolved-attribute]` for dynamic `.parser` and `func.__name__` attribute accesses (ty uses its own comment format)
- Update tests: use `argparse.Namespace` instead of `namedtuple`, fix `Optional` annotations in helper functions

## Test plan

- [ ] `ty check` passes with zero diagnostics
- [ ] All 145 existing tests pass (`pytest`)
- [ ] `pre-commit run --all-files` passes with the new ty hook

https://claude.ai/code/session_01S7P2NxxWVw17rQC8WXdtRf